### PR TITLE
Logistics logs for Retail Seller as LBNP - Flows A1, A2, A3, A5

### DIFF
--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Downloaded_logs_LBNP.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Downloaded_logs_LBNP.json
@@ -1,0 +1,3762 @@
+{
+    "domain": "nic2004:60232",
+    "payload": {
+      "search_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745516797\",expires=\"1745546797155\",headers=\"(created) (expires) digest\",signature=\"EtQMDgWNcGUpeXHlmpRjAiVoqhzZUGhrfpFVYpWF+13kf1rUDceXwPhqqfOj0UX3nBDFlUDHeZnA69KVp9WNAg==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "search",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "7ca9ff7e-9c13-4762-af09-473143c2dbfb",
+            "timestamp": "2025-04-24T17:46:37.155Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "intent": {
+              "category": {
+                "id": "Standard Delivery"
+              },
+              "provider": {
+                "time": {
+                  "days": "1,2,3,4,5,6,7",
+                  "schedule": {
+                    "holidays": []
+                  },
+                  "duration": "P0DT0H1M",
+                  "range": {
+                    "start": "0001",
+                    "end": "2359"
+                  }
+                }
+              },
+              "fulfillment": {
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "area_code": "560103"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              "payment": {
+                "type": "ON-ORDER"
+              },
+              "@ondc/org/payload_details": {
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                },
+                "category": "Grocery",
+                "value": {
+                  "currency": "INR",
+                  "value": "880"
+                },
+                "dangerous_goods": false
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "search",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "7ca9ff7e-9c13-4762-af09-473143c2dbfb",
+            "timestamp": "2025-04-24T17:46:37.155Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_search_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745516798\",expires=\"1745520398\",headers=\"(created) (expires) digest\",signature=\"xJmzdvrP0JNg34FDhftlyUku4mWJDxUDMhMCfv9c00NXa2rz3WgSpmrNOqaYfo5y6Eg8Fep2oVOIJFOx28FHCA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "7ca9ff7e-9c13-4762-af09-473143c2dbfb",
+            "timestamp": "2025-04-24T17:46:38.224Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "catalog": {
+              "bpp/descriptor": {
+                "name": "ONDC Pramaaan Logistics"
+              },
+              "bpp/providers": [
+                {
+                  "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "descriptor": {
+                    "name": "ONDC Pramaaan Logistics",
+                    "short_desc": "Swiftly Yours, Delivered with Care",
+                    "long_desc": "We deliver everywhere—yes, even Mars (just give us a little more rocket fuel)."
+                  },
+                  "categories": [
+                    {
+                      "id": "Standard Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "Immediate Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      }
+                    },
+                    {
+                      "id": "Express Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "Next Day Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "Same Day Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  ],
+                  "fulfillments": [
+                    {
+                      "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT15M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT20M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "a60ad63c-b760-42be-98e0-6022237da726",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT30M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT30M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT15M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "aed7bdf2-f09a-4e9e-8ed1-ba89731e519c",
+                      "type": "RTO"
+                    }
+                  ],
+                  "items": [
+                    {
+                      "id": "rto_std",
+                      "parent_item_id": "std_del",
+                      "category_id": "Standard Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "fulfillment_id": "aed7bdf2-f09a-4e9e-8ed1-ba89731e519c",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "rto_imd",
+                      "parent_item_id": "imd_del",
+                      "category_id": "Immediate Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Immediate Delivery",
+                        "long_desc": "Upto 60 mins for Delivery",
+                        "short_desc": "Upto 60 mins for Delivery"
+                      },
+                      "fulfillment_id": "aed7bdf2-f09a-4e9e-8ed1-ba89731e519c",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "imd_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Immediate Delivery",
+                        "long_desc": "Upto 60 mins for Delivery",
+                        "short_desc": "Upto 60 mins for Delivery"
+                      },
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      }
+                    },
+                    {
+                      "id": "rto_exp",
+                      "parent_item_id": "exp_del",
+                      "category_id": "Express Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Express Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "fulfillment_id": "aed7bdf2-f09a-4e9e-8ed1-ba89731e519c",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "exp_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Express Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Express Delivery",
+                      "fulfillment_id": "a60ad63c-b760-42be-98e0-6022237da726",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "rto_nex",
+                      "parent_item_id": "nex_del",
+                      "category_id": "Next Day Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Next Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "fulfillment_id": "aed7bdf2-f09a-4e9e-8ed1-ba89731e519c",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "nex_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Next Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Next Day Delivery",
+                      "fulfillment_id": "a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "rto_same",
+                      "parent_item_id": "same_del",
+                      "category_id": "Same Day Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Same Day Delivery",
+                        "long_desc": "Same Delivery",
+                        "short_desc": "Same for Delivery"
+                      },
+                      "fulfillment_id": "aed7bdf2-f09a-4e9e-8ed1-ba89731e519c",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "same_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Same Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Same Day Delivery",
+                      "fulfillment_id": "1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "7ca9ff7e-9c13-4762-af09-473143c2dbfb",
+            "timestamp": "2025-04-24T17:46:38.224Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK",
+              "tags": [
+                {
+                  "display": true,
+                  "code": "string",
+                  "name": "string",
+                  "list": [
+                    {
+                      "code": "string",
+                      "name": "string",
+                      "value": "string",
+                      "display": true
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "error": {
+            "type": "CONTEXT-ERROR",
+            "code": "string",
+            "path": "string",
+            "message": "string"
+          }
+        }
+      },
+      "init_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745516859\",expires=\"1745546859218\",headers=\"(created) (expires) digest\",signature=\"8cIO5HyMCOvx2+v5XSWzY7Kyu1emPduRNAf73Z/VJrPmKFAwNt1AmOYUF4b/1r9A8OnPJbmA0lNm7PDLhTQ/Aw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f589b8f7-ed7d-4fa7-8bef-9c07e4697385",
+            "timestamp": "2025-04-24T17:47:39.218Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "category_id": "Standard Delivery",
+                  "descriptor": {
+                    "code": "P2P"
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f589b8f7-ed7d-4fa7-8bef-9c07e4697385",
+            "timestamp": "2025-04-24T17:47:39.218Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_init_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745516859\",expires=\"1745520459\",headers=\"(created) (expires) digest\",signature=\"0bmwN+IXHcFSF5bWXpBsHwYJIef9+ZOycu2PANLcozkWSEYoOhqMQuWDPOMjqxL1rf6oJJzs8BIQRzWLGERSDQ==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f589b8f7-ed7d-4fa7-8bef-9c07e4697385",
+            "timestamp": "2025-04-24T17:47:39.253Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  }
+                }
+              ],
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ],
+                "ttl": "P7D"
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f589b8f7-ed7d-4fa7-8bef-9c07e4697385",
+            "timestamp": "2025-04-24T17:47:39.253Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK",
+              "tags": [
+                {
+                  "display": true,
+                  "code": "string",
+                  "name": "string",
+                  "list": [
+                    {
+                      "code": "string",
+                      "name": "string",
+                      "value": "string",
+                      "display": true
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "confirm_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745516876\",expires=\"1745546876072\",headers=\"(created) (expires) digest\",signature=\"c36TNv7fEfFa4paE8eybvIBqfCF+AfRbwf6QWpvqXMJxIRXne74H5SIUqwaakUX1opRG4d88QVjwI6eYVOaSDg==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "confirm",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "88e54322-2877-4d95-8d47-8840c205cc4f",
+            "timestamp": "2025-04-24T17:47:56.072Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "category_id": "Standard Delivery",
+                  "descriptor": {
+                    "code": "P2P"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "id": "SS1745516875776",
+              "state": "Created",
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745516875776",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "tags": [
+                {
+                  "code": "bap_terms",
+                  "list": [
+                    {
+                      "code": "accept_bpp_terms",
+                      "value": "Y"
+                    }
+                  ]
+                }
+              ],
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:47:56.027Z"
+            }
+          }
+        },
+        "response": {
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_confirm_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745516876\",expires=\"1745520476\",headers=\"(created) (expires) digest\",signature=\"30uJ0yqJgZm3PX1g/NHwslbU9wSssEj74c28D3Nq6FUa9CiFxVhyvh7H/2I7+Y5w8xhgEyJorhwkPIQGt965Cg==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "88e54322-2877-4d95-8d47-8840c205cc4f",
+            "timestamp": "2025-04-24T17:47:56.118Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "Accepted",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Pending"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745516875776",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:47:56.118Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "88e54322-2877-4d95-8d47-8840c205cc4f",
+            "timestamp": "2025-04-24T17:47:56.118Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "update_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517227\",expires=\"1745547227396\",headers=\"(created) (expires) digest\",signature=\"9/Lx/Ka1woMDBsAiMc5t050z0N20Q+0wr87gFTb9dwZUHlthnMnHaqnXDzFeeAlA+Gl6jzyq41wxm8RurqbaAQ==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "update",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "5ea426da-4964-4e56-83e4-38389f631eac",
+            "timestamp": "2025-04-24T17:53:47.396Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "update_target": "fulfillment",
+            "order": {
+              "id": "SS1745516875776",
+              "state": "Created",
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "descriptor": {
+                    "code": "P2P"
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship",
+                          "value": "yes"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "updated_at": "2025-04-24T23:23:47.382Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "update",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "5ea426da-4964-4e56-83e4-38389f631eac",
+            "timestamp": "2025-04-24T17:53:47.396Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_update_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517228\",expires=\"1745520828\",headers=\"(created) (expires) digest\",signature=\"3drcszrhdKVKZgYTaqKBlA/FRPHDtaUHCyvc2moZoSXVZWQoYx2YVdWoL2E3mRRU4YERh+RxXSw0uyYbNut9Ag==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_update",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "5ea426da-4964-4e56-83e4-38389f631eac",
+            "timestamp": "2025-04-24T17:53:48.865Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "Accepted",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Searching-for-Agent"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745516875776",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:47:56.118Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_update",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "5ea426da-4964-4e56-83e4-38389f631eac",
+            "timestamp": "2025-04-24T17:53:48.865Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517244\",expires=\"1745520844\",headers=\"(created) (expires) digest\",signature=\"TvFenxwdj9hSBe1NGkqs1EbD0Gk1RPsygrbz9FDz4bKJV657v7y2xQ86n4a7x0GwZN9uPP27tSv/4vMj2wZYCQ==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "a7e45dcd-8475-47f9-a116-fca6defb55c5",
+            "timestamp": "2025-04-24T17:54:04.004Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Agent-assigned"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745516875776",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:54:04.004Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "a7e45dcd-8475-47f9-a116-fca6defb55c5",
+            "timestamp": "2025-04-24T17:54:04.004Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_2": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517247\",expires=\"1745520847\",headers=\"(created) (expires) digest\",signature=\"8rEnBvQ2Z9le6GIlEQrfGKY/ZRUcDXYBhqNaDht+tDtd7DVPeFKs0ehjm10JEyQhYbOjGXbxKXCNH/xNXuVHAQ==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "23e9aab1-0d67-4b30-a39d-47f7121e1225",
+            "timestamp": "2025-04-24T17:54:07.007Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-picked-up"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:07.007Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "status": "NOT-PAID"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745516875776",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:54:07.007Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "23e9aab1-0d67-4b30-a39d-47f7121e1225",
+            "timestamp": "2025-04-24T17:54:07.007Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_3": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517254\",expires=\"1745520854\",headers=\"(created) (expires) digest\",signature=\"FImrqe2O38bCzqEK4Nx9xJUVbByHoeQnYCMKU8o8WLzZuhzmjn2lwAUigpibQM6bwkeFh91ChqVGSyFBxZCZAw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "5f0b17a3-7feb-469e-a8c7-fa0df51f8145",
+            "timestamp": "2025-04-24T17:54:14.455Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Out-for-delivery"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:07.007Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "status": "NOT-PAID"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745516875776",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:54:14.455Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "5f0b17a3-7feb-469e-a8c7-fa0df51f8145",
+            "timestamp": "2025-04-24T17:54:14.455Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "track_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517265\",expires=\"1745547265898\",headers=\"(created) (expires) digest\",signature=\"NDIZgEzmcgvN9Cs3oX6Az0xq/vtZzZmxzIsSce+TY16G/2gqVKlhMGBBt4DoEYcMYeccgIcKYln2vWbV3S6fDw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "track",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "5e2d673d-f5e6-4916-803d-1aebba93e932",
+            "timestamp": "2025-04-24T17:54:25.898Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order_id": "SS1745516875776"
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_track",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "5e2d673d-f5e6-4916-803d-1aebba93e932",
+            "timestamp": "2025-04-24T17:54:25.898Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_track_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517267\",expires=\"1745520867\",headers=\"(created) (expires) digest\",signature=\"GImKzBFKFYkm7dsCmYbI0L4+UbmsWQbzKcgOw0oZn3kaCaW+vdQ/tvTmAQRQ1/guJMrUU6KBGhPlTF+WHKm+Ag==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_track",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "5e2d673d-f5e6-4916-803d-1aebba93e932",
+            "timestamp": "2025-04-24T17:54:25.898Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "tracking": {
+              "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+              "url": "http://sequelstring-lsp-ondc.com/track",
+              "location": {
+                "gps": "12.974002,77.613458",
+                "time": {
+                  "timestamp": "2025-04-24T17:54:27.374Z"
+                },
+                "updated_at": "2025-04-24T17:54:27.374Z"
+              },
+              "status": "active",
+              "tags": [
+                {
+                  "code": "order",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "SS1745516875776"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "attr",
+                      "value": "tracking.location.gps"
+                    },
+                    {
+                      "code": "type",
+                      "value": "live_poll"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_track",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "5e2d673d-f5e6-4916-803d-1aebba93e932",
+            "timestamp": "2025-04-24T17:54:25.898Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "status_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517287\",expires=\"1745547287637\",headers=\"(created) (expires) digest\",signature=\"09QbHtw6vmobwSX+NWzEWWdr1qWGvRIRMqjQ4RywYTxFwKV86PZd5V4ZEk5gyz1C2672iCRr/ylzfZ+6CeZ8AA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "c79086ea-9698-4530-a287-ab3f26fa5eff",
+            "timestamp": "2025-04-24T17:54:47.637Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order_id": "SS1745516875776"
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "c79086ea-9698-4530-a287-ab3f26fa5eff",
+            "timestamp": "2025-04-24T17:54:47.637Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_4": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517290\",expires=\"1745520890\",headers=\"(created) (expires) digest\",signature=\"LrFIrac02cpPwPFGyfshEyUdAoFQ0y/0JHyEwSWFxrgz0402RRqNeWmtzff9SQxjtpBKlvT3YSGN1mLwrHGcCw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "c79086ea-9698-4530-a287-ab3f26fa5eff",
+            "timestamp": "2025-04-24T17:54:50.085Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Out-for-delivery"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:07.007Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "status": "NOT-PAID"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745516875776",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:54:14.455Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "c79086ea-9698-4530-a287-ab3f26fa5eff",
+            "timestamp": "2025-04-24T17:54:50.085Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_5": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517297\",expires=\"1745520897\",headers=\"(created) (expires) digest\",signature=\"LSsBleRBF0UpISESXurobUvnyOzHnBw3FDKa7ArUYb4GdFtviPFwLOHvI83VAa2WBywvD1Pw3JHSAyUH6DVVBw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "adeecf7a-a950-4d43-948a-6b6a458ef8bd",
+            "timestamp": "2025-04-24T17:54:57.800Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "Completed",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-delivered"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:07.007Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:57.800Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Delivery",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "status": "NOT-PAID",
+                "time": {
+                  "timestamp": "2025-04-24T17:54:57.800Z"
+                }
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745516875776",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:54:57.800Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "adeecf7a-a950-4d43-948a-6b6a458ef8bd",
+            "timestamp": "2025-04-24T17:54:57.800Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "status_2": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517303\",expires=\"1745547303137\",headers=\"(created) (expires) digest\",signature=\"VgkyaASRB/BZVLTOEA4IiLOIpNhoJNljNzrPSNp6BRgngk78nh/q7Wnij13PTB9ZzHvWvPKjFEvU/GepJpBQAw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "9584a9f7-a0f9-4ed2-9aaa-7e7b34f41b60",
+            "timestamp": "2025-04-24T17:55:03.137Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order_id": "SS1745516875776"
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "9584a9f7-a0f9-4ed2-9aaa-7e7b34f41b60",
+            "timestamp": "2025-04-24T17:55:03.137Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_6": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517304\",expires=\"1745520904\",headers=\"(created) (expires) digest\",signature=\"piFa4m1noZBVKtAIJfpfLkwvwf9Om0Y5XZkNF1U+ABPk1yUTU3qpn/cR4gP4+HvI4ZcNrQlmRluxFcKvTAOLBA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "9584a9f7-a0f9-4ed2-9aaa-7e7b34f41b60",
+            "timestamp": "2025-04-24T17:55:04.604Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "Completed",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-delivered"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:07.007Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:57.800Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Delivery",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "status": "NOT-PAID",
+                "time": {
+                  "timestamp": "2025-04-24T17:54:57.800Z"
+                }
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745516875776",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:54:57.800Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "9584a9f7-a0f9-4ed2-9aaa-7e7b34f41b60",
+            "timestamp": "2025-04-24T17:55:04.604Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      }
+    }
+  }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Downloaded_logs_Retail.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Downloaded_logs_Retail.json
@@ -1,0 +1,7598 @@
+{
+    "domain": "ONDC:RET10",
+    "payload": {
+      "search_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745516720\",expires=\"1745520320\",headers=\"(created) (expires) digest\",signature=\"sqKE7G9iqXyHJ5G7HP81avpJX862XqeOky8/8MbjtX8izCXedWjOH8Nulqh0KufqUqNnEaCt9exM/W0dfTgMBg==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "search",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "d61a2ea2-d544-4d90-a3db-85be2ca13675",
+            "timestamp": "2025-04-24T17:45:20.418Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "intent": {
+              "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3"
+              },
+              "tags": [
+                {
+                  "code": "catalog_full",
+                  "list": [
+                    {
+                      "code": "payload_type",
+                      "value": "inline"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "action": "search",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "d61a2ea2-d544-4d90-a3db-85be2ca13675",
+            "timestamp": "2025-04-24T17:45:20.532Z",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_search_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745516724\",expires=\"1745546724655\",headers=\"(created) (expires) digest\",signature=\"beuH6E7GeucnfCHgSrjFK/+ERQaoEup177UiudmU6EqJx7AMZtOQ48P70HveKOugustELCU4pptfCkxZbXLOAA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "d61a2ea2-d544-4d90-a3db-85be2ca13675",
+            "timestamp": "2025-04-24T17:45:24.651Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "catalog": {
+              "bpp/fulfillments": [
+                {
+                  "id": "1",
+                  "type": "Delivery",
+                  "contact": {
+                    "phone": "9900025784",
+                    "email": "sgupta.scm@gmail.com"
+                  }
+                }
+              ],
+              "bpp/descriptor": {
+                "name": "Lekhha",
+                "symbol": "https://lekhha.com/wp-content/uploads/2023/07/logo-light-1.png",
+                "short_desc": "App-based platform for order and inventory management.",
+                "long_desc": "LEKHHA is a simple solution to help you comprehensively run your business operations. Discover it to also track & manage your personal needs & resources. Reach out to us to serve you as your solution partner.",
+                "images": [
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/logo",
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/vendor",
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/consumer",
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/inventory"
+                ],
+                "tags": [
+                  {
+                    "code": "bpp_terms",
+                    "list": [
+                      {
+                        "code": "np_type",
+                        "value": "MSN"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "bpp/providers": [
+                {
+                  "id": "674ecb33d7b9e10f4210d972",
+                  "time": {
+                    "label": "enable",
+                    "timestamp": "2025-04-24T17:45:23.878Z"
+                  },
+                  "descriptor": {
+                    "name": "Lekhha Provider A",
+                    "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecb33d7b9e10f4210d972_S",
+                    "short_desc": "Lekhha_Seller_1 kyc short",
+                    "long_desc": "Lekhha_Seller_1 kyc long",
+                    "images": [
+                      "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecb33d7b9e10f4210d972"
+                    ]
+                  },
+                  "ttl": "P1D",
+                  "creds": [
+                    {
+                      "descriptor": {
+                        "code": "Lekhha_Seller_1_cred1",
+                        "name": "Lekhha_Seller_1 cred1",
+                        "short_desc": "Lekhha_Seller_1 cred1 short"
+                      },
+                      "id": "674ecbc6d7b9e10f4210d973_1",
+                      "tags": [
+                        {
+                          "code": "verification",
+                          "list": [
+                            {
+                              "code": "verify_url",
+                              "value": "https://url1url.com/verify1"
+                            },
+                            {
+                              "code": "valid_from",
+                              "value": "2024-12-09T00:00:00.000Z"
+                            },
+                            {
+                              "code": "valid_to",
+                              "value": "2027-03-31T00:00:00.000Z"
+                            }
+                          ]
+                        }
+                      ],
+                      "url": "https://url1url.com"
+                    }
+                  ],
+                  "fulfillments": [
+                    {
+                      "id": "1",
+                      "type": "Delivery",
+                      "contact": {
+                        "phone": "9900025784",
+                        "email": "sgupta.scm@gmail.com"
+                      }
+                    }
+                  ],
+                  "tags": [
+                    {
+                      "code": "order_value",
+                      "list": [
+                        {
+                          "code": "min_value",
+                          "value": "150.5"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "timing",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "Order"
+                        },
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "day_from",
+                          "value": "1"
+                        },
+                        {
+                          "code": "day_to",
+                          "value": "7"
+                        },
+                        {
+                          "code": "time_from",
+                          "value": "0001"
+                        },
+                        {
+                          "code": "time_to",
+                          "value": "2359"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "timing",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "Delivery"
+                        },
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "day_from",
+                          "value": "1"
+                        },
+                        {
+                          "code": "day_to",
+                          "value": "7"
+                        },
+                        {
+                          "code": "time_from",
+                          "value": "0001"
+                        },
+                        {
+                          "code": "time_to",
+                          "value": "2359"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "timing",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "Self-Pickup"
+                        },
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "day_from",
+                          "value": "1"
+                        },
+                        {
+                          "code": "day_to",
+                          "value": "7"
+                        },
+                        {
+                          "code": "time_from",
+                          "value": "0001"
+                        },
+                        {
+                          "code": "time_to",
+                          "value": "2359"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "serviceability",
+                      "list": [
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "category",
+                          "value": "Bakery, Cakes & Dairy"
+                        },
+                        {
+                          "code": "type",
+                          "value": "11"
+                        },
+                        {
+                          "code": "val",
+                          "value": "100000-999999"
+                        },
+                        {
+                          "code": "unit",
+                          "value": "pincode"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "serviceability",
+                      "list": [
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "category",
+                          "value": "Energy and Soft Drinks"
+                        },
+                        {
+                          "code": "type",
+                          "value": "11"
+                        },
+                        {
+                          "code": "val",
+                          "value": "100000-999999"
+                        },
+                        {
+                          "code": "unit",
+                          "value": "pincode"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "serviceability",
+                      "list": [
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "category",
+                          "value": "Fruits and Vegetables"
+                        },
+                        {
+                          "code": "type",
+                          "value": "11"
+                        },
+                        {
+                          "code": "val",
+                          "value": "100000-999999"
+                        },
+                        {
+                          "code": "unit",
+                          "value": "pincode"
+                        }
+                      ]
+                    }
+                  ],
+                  "items": [
+                    {
+                      "id": "676a61f6cac4860876a8e30f",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.155Z"
+                      },
+                      "parent_item_id": "V10000000001",
+                      "descriptor": {
+                        "name": "Milk orange",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk orange short",
+                        "long_desc": "Milk orange long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e3_0"
+                        ],
+                        "code": "1:1000000000232"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "13"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "49.82",
+                        "maximum_value": "53.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 11",
+                        "additives_info": "additives info 11",
+                        "brand_owner_FSSAI_license_no": "fssai license 11",
+                        "other_FSSAI_license_no": "other license 11",
+                        "importer_FSSAI_license_no": "importer license 11"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 11",
+                        "manufacturer_or_packer_address": "address 11",
+                        "common_or_generic_name_of_commodity": "commodity 11",
+                        "month_year_of_manufacture_packing_import": "year 11"
+                      }
+                    },
+                    {
+                      "id": "676a6179cac4860876a8e30b",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.185Z"
+                      },
+                      "parent_item_id": "V10000000002",
+                      "descriptor": {
+                        "name": "Milk blue",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk blue short",
+                        "long_desc": "Milk blue long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e5_0"
+                        ],
+                        "code": "1:1000000000233"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "10"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "12"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "380.00",
+                        "maximum_value": "400.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 9",
+                        "additives_info": "additives info 9",
+                        "brand_owner_FSSAI_license_no": "fssai license 9",
+                        "other_FSSAI_license_no": "other license 9",
+                        "importer_FSSAI_license_no": "importer license 9"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 9",
+                        "manufacturer_or_packer_address": "address 9",
+                        "common_or_generic_name_of_commodity": "commodity 9",
+                        "month_year_of_manufacture_packing_import": "year 9"
+                      }
+                    },
+                    {
+                      "id": "676a6260cac4860876a8e311",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.217Z"
+                      },
+                      "parent_item_id": "V10000000001",
+                      "descriptor": {
+                        "name": "Milk orange",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk orange short",
+                        "long_desc": "Milk orange long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e7_0"
+                        ],
+                        "code": "1:1000000000234"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "10"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "14"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "500.00",
+                        "maximum_value": "500.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 12",
+                        "additives_info": "additives info 12",
+                        "brand_owner_FSSAI_license_no": "fssai license 12",
+                        "other_FSSAI_license_no": "other license 12",
+                        "importer_FSSAI_license_no": "importer license 12"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 12",
+                        "manufacturer_or_packer_address": "address 12",
+                        "common_or_generic_name_of_commodity": "commodity 12",
+                        "month_year_of_manufacture_packing_import": "year 12"
+                      }
+                    },
+                    {
+                      "id": "676cf465e5eb3c28a8741e99",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.313Z"
+                      },
+                      "descriptor": {
+                        "name": "Pista milk",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Pista milk short",
+                        "long_desc": "Pista milk long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd72c_0"
+                        ],
+                        "code": "1:1000000000240"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "32"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "18.50",
+                        "maximum_value": "20.00"
+                      },
+                      "category_id": "Energy and Soft Drinks",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 18",
+                        "additives_info": "additives info 18",
+                        "brand_owner_FSSAI_license_no": "fssai license 18",
+                        "other_FSSAI_license_no": "other license 18",
+                        "importer_FSSAI_license_no": "importer license 18"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 18",
+                        "manufacturer_or_packer_address": "address 18",
+                        "common_or_generic_name_of_commodity": "commodity 18",
+                        "month_year_of_manufacture_packing_import": "year 18"
+                      }
+                    },
+                    {
+                      "id": "676cf465e5eb3c28a8741e9a",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.332Z"
+                      },
+                      "descriptor": {
+                        "name": "Mango milk",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Mango milk short",
+                        "long_desc": "Mango milk long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd72e_0"
+                        ],
+                        "code": "1:1000000000241"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "33"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "20.16",
+                        "maximum_value": "21.80"
+                      },
+                      "category_id": "Energy and Soft Drinks",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 7",
+                        "additives_info": "additives info 7",
+                        "brand_owner_FSSAI_license_no": "fssai license 7",
+                        "other_FSSAI_license_no": "other license 7",
+                        "importer_FSSAI_license_no": "importer license 7"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 7",
+                        "manufacturer_or_packer_address": "address 7",
+                        "common_or_generic_name_of_commodity": "commodity 7",
+                        "month_year_of_manufacture_packing_import": "year 7"
+                      }
+                    },
+                    {
+                      "id": "676cf465e5eb3c28a8741e9b",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.349Z"
+                      },
+                      "descriptor": {
+                        "name": "Vanilla milk",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Vanilla milk short",
+                        "long_desc": "Vanilla milk long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd730_0"
+                        ],
+                        "code": "1:1000000000242"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "35"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "18.51",
+                        "maximum_value": "20.01"
+                      },
+                      "category_id": "Energy and Soft Drinks",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 19",
+                        "additives_info": "additives info 19",
+                        "brand_owner_FSSAI_license_no": "fssai license 19",
+                        "other_FSSAI_license_no": "other license 19",
+                        "importer_FSSAI_license_no": "importer license 19"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer name 19",
+                        "manufacturer_or_packer_address": "packer address 19",
+                        "common_or_generic_name_of_commodity": "generic name 19",
+                        "month_year_of_manufacture_packing_import": "month year 19"
+                      }
+                    },
+                    {
+                      "id": "676a5f87cac4860876a8e2ff",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.362Z"
+                      },
+                      "descriptor": {
+                        "name": "Butter",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Butter short",
+                        "long_desc": "Butter long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd736_0"
+                        ],
+                        "code": "1:1000000000245"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "gram",
+                            "value": "200"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "23"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "109.38",
+                        "maximum_value": "124.30"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 3",
+                        "additives_info": "additives info 3",
+                        "brand_owner_FSSAI_license_no": "fssai license 3",
+                        "other_FSSAI_license_no": "other license 3",
+                        "importer_FSSAI_license_no": "importer license 3"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 13",
+                        "manufacturer_or_packer_address": "address 13",
+                        "common_or_generic_name_of_commodity": "commodity 13",
+                        "month_year_of_manufacture_packing_import": "year 13"
+                      }
+                    },
+                    {
+                      "id": "676a5f11cac4860876a8e2fb",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.373Z"
+                      },
+                      "descriptor": {
+                        "name": "Burfi",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Burfi short",
+                        "long_desc": "Burfi long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd73a_0"
+                        ],
+                        "code": "1:1000000000247"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "gram",
+                            "value": "200"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "22"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "71.20",
+                        "maximum_value": "80.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 2",
+                        "additives_info": "additives info 2",
+                        "brand_owner_FSSAI_license_no": "fssai license 2",
+                        "other_FSSAI_license_no": "other license 2",
+                        "importer_FSSAI_license_no": "importer license 2"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer name 2",
+                        "manufacturer_or_packer_address": "packer address 2",
+                        "common_or_generic_name_of_commodity": "commodity 2",
+                        "month_year_of_manufacture_packing_import": "packing import 2"
+                      }
+                    },
+                    {
+                      "id": "676aab3800d7d9212e3ba074",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.386Z"
+                      },
+                      "descriptor": {
+                        "name": "Watermelon",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Watermelon short",
+                        "long_desc": "Watermelon long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd740_0"
+                        ],
+                        "code": "1:2000000000349"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "46"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "45.00",
+                        "maximum_value": "45.00"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a9e1d00d7d9212e3b8f7f",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.401Z"
+                      },
+                      "descriptor": {
+                        "name": "Apple",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Apple short",
+                        "long_desc": "Apple long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd742_0"
+                        ],
+                        "code": "1:2000000000341"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "21"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "120.02",
+                        "maximum_value": "120.02"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676aaa5700d7d9212e3ba019",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.412Z"
+                      },
+                      "descriptor": {
+                        "name": "Papaya",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Papaya short",
+                        "long_desc": "Papaya long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd746_0"
+                        ],
+                        "code": "1:2000000000346"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "29"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "61.28",
+                        "maximum_value": "64.50"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a9fa200d7d9212e3b8fbd",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.427Z"
+                      },
+                      "descriptor": {
+                        "name": "Beetroot",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Beetroot short",
+                        "long_desc": "Beetroot long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6762dbb841c7aa7c86d1d1c2_0"
+                        ],
+                        "code": "1:2000000000343"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "0"
+                        },
+                        "maximum": {
+                          "count": "6"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "30.00",
+                        "maximum_value": "30.00"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a9f7800d7d9212e3b8fbb",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.438Z"
+                      },
+                      "descriptor": {
+                        "name": "Beans haricot",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Beans haricot short",
+                        "long_desc": "Beans haricot long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6762dbb841c7aa7c86d1d1c4_0"
+                        ],
+                        "code": "1:2000000000342"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "0"
+                        },
+                        "maximum": {
+                          "count": "5"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "76.42",
+                        "maximum_value": "78.38"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a6126cac4860876a8e309",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.519Z"
+                      },
+                      "parent_item_id": "V10000000002",
+                      "descriptor": {
+                        "name": "Milk blue",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk blue short",
+                        "long_desc": "Milk blue long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e1_0"
+                        ],
+                        "code": "1:1000000000231"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "11"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00",
+                        "maximum_value": "40.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 8",
+                        "additives_info": "additives info 8",
+                        "brand_owner_FSSAI_license_no": "fssai license 8",
+                        "other_FSSAI_license_no": "other license 8",
+                        "importer_FSSAI_license_no": "importer license 8"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 8",
+                        "manufacturer_or_packer_address": "address 8",
+                        "common_or_generic_name_of_commodity": "commodity 8",
+                        "month_year_of_manufacture_packing_import": "year 8"
+                      }
+                    }
+                  ],
+                  "locations": [
+                    {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:23.899Z",
+                        "days": "1,2,3,4,5,6,7",
+                        "schedule": {
+                          "holidays": []
+                        },
+                        "range": {
+                          "start": "0001",
+                          "end": "2359"
+                        }
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "locality": "Bengaluru",
+                        "street": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "city": "Bengaluru",
+                        "area_code": "560103",
+                        "state": "KA"
+                      },
+                      "circle": {
+                        "gps": "12.9263841,77.6654374",
+                        "radius": {
+                          "unit": "km",
+                          "value": "999"
+                        }
+                      }
+                    }
+                  ],
+                  "categories": [
+                    {
+                      "id": "V10000000001",
+                      "descriptor": {
+                        "name": "Variant Group 10000000001"
+                      },
+                      "tags": [
+                        {
+                          "code": "type",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "variant_group"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "attr",
+                          "list": [
+                            {
+                              "code": "name",
+                              "value": "item.quantity.unitized.measure"
+                            },
+                            {
+                              "code": "seq",
+                              "value": "1"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "V10000000002",
+                      "descriptor": {
+                        "name": "Variant Group 10000000002"
+                      },
+                      "tags": [
+                        {
+                          "code": "type",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "variant_group"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "attr",
+                          "list": [
+                            {
+                              "code": "name",
+                              "value": "item.quantity.unitized.measure"
+                            },
+                            {
+                              "code": "seq",
+                              "value": "1"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "d61a2ea2-d544-4d90-a3db-85be2ca13675",
+            "timestamp": "2025-04-24T17:45:24.651Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            },
+            "tags": [
+              {
+                "code": "CATALOG_PROCESSING",
+                "list": [
+                  {
+                    "code": "MIN_PROCESS_DURATION",
+                    "value": "PT1S"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "select_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745516796\",expires=\"1745520396\",headers=\"(created) (expires) digest\",signature=\"1JOl0aWn1cf6hkbhP8cSMpefgY0cu60a6AwKKRalQPr+9pAC+FATR061sV0eCsURYV80a5DSq1FPlc+7eyhWBA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "select",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "40b6f53d-ac0d-4739-ac1d-2408a3445482",
+            "timestamp": "2025-04-24T17:46:36.533Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  }
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                }
+              ],
+              "payment": {
+                "type": "ON-ORDER"
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "select",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "40b6f53d-ac0d-4739-ac1d-2408a3445482",
+            "timestamp": "2025-04-24T17:46:36.805Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_select_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745516805\",expires=\"1745546805096\",headers=\"(created) (expires) digest\",signature=\"famnM13/57LUMLNm/9jsx8nePoQlW0EsF8yjdSDscggvvjdEheR/ZHl8+h7nW2rdST+Dfwojk2VvjgIwJiYmDQ==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_select",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "40b6f53d-ac0d-4739-ac1d-2408a3445482",
+            "timestamp": "2025-04-24T17:46:45.092Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "id": "676a6179cac4860876a8e30b",
+                  "quantity": {
+                    "count": 2
+                  }
+                },
+                {
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "id": "676a6126cac4860876a8e309",
+                  "quantity": {
+                    "count": 3
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c27~I1~1~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Ecom Express Limited",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P5D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c28~19537~YAARI-19537-20250424-U2JJE6IXS4~SY-1745516797923-51",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Ecom Express",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "NS_LSP",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "PT55M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "NS_LSP",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "PT55M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Immediate Delivery",
+                  "@ondc/org/TAT": "PT60M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~a60ad63c-b760-42be-98e0-6022237da726",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Express Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Next Day Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Same Day Delivery",
+                  "@ondc/org/TAT": "PT4H",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c2b~Delhivery~3204dd9f-423a-46a7-8b94-f11642a83977~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Delhivery",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P4D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c2c~P1~I1~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Bharat Mart",
+                  "tracking": false,
+                  "@ondc/org/category": "Immediate Delivery",
+                  "@ondc/org/TAT": "PT60M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78ff48665475e6bf8c2f~MOVERDELIVERY~I1~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Mover",
+                  "tracking": false,
+                  "@ondc/org/category": "Immediate Delivery",
+                  "@ondc/org/TAT": "PT30M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78ff48665475e6bf8c30~Bluedart Express~BDEEP0~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Bluedart Express",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P4D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a790048665475e6bf8c31~DTDC~B2C SMART EXPRESS~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "DTDC",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P4D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a790048665475e6bf8c32~P1~I1~I1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Exeed Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P8D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "129831.05"
+                },
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "quantity": {
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "12"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "quantity": {
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "11"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c27~I1~1~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "69"
+                    },
+                    "lsp_provider_id": "I1",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "1",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "name": "Standard Delivery",
+                        "code": "P2H2P",
+                        "short_desc": "Fast Delivery For Items",
+                        "long_desc": "Fast Delivery for Items"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "1",
+                      "price": {
+                        "currency": "INR",
+                        "value": "69"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "timestamp": "2025-04-28",
+                        "duration": "P5D"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c28~19537~YAARI-19537-20250424-U2JJE6IXS4~SY-1745516797923-51",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "395.74"
+                    },
+                    "lsp_provider_id": "19537",
+                    "lsp_fulfillment_id": "SY-1745516797923-51",
+                    "lsp_item_details": {
+                      "id": "YAARI-19537-20250424-U2JJE6IXS4",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "SY-1745516797923-51",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Ecom Express",
+                        "short_desc": "Ecom Express",
+                        "long_desc": "Ecom Express"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "395.74"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "2.0"
+                    },
+                    "lsp_provider_id": "NS_LSP",
+                    "lsp_fulfillment_id": "ns_immediate_f1",
+                    "lsp_item_details": {
+                      "id": "ns_immediate",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "ns_immediate_f1",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "NS LSP Immediate Delivery",
+                        "short_desc": "Immediate Delivery by NS LSP",
+                        "long_desc": "Immediate Delivery by NS LSP"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2.0"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT55M",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    },
+                    "lsp_provider_id": "NS_LSP",
+                    "lsp_fulfillment_id": "ns_immediate_f1-RTO",
+                    "lsp_item_details": {
+                      "id": "ns_immediate-RTO",
+                      "parent_item_id": "ns_immediate",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "ns_immediate_f1-RTO",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "RTO quote",
+                        "short_desc": "RTO quote",
+                        "long_desc": "RTO quote"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "0"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT55M",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                    "lsp_item_details": {
+                      "id": "imd_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Immediate Delivery",
+                        "long_desc": "Upto 60 mins for Delivery",
+                        "short_desc": "Upto 60 mins for Delivery"
+                      },
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~a60ad63c-b760-42be-98e0-6022237da726",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "a60ad63c-b760-42be-98e0-6022237da726",
+                    "lsp_item_details": {
+                      "id": "exp_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Express Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Express Delivery",
+                      "fulfillment_id": "a60ad63c-b760-42be-98e0-6022237da726",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                    "lsp_item_details": {
+                      "id": "nex_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Next Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Next Day Delivery",
+                      "fulfillment_id": "a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                    "lsp_item_details": {
+                      "id": "same_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Same Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Same Day Delivery",
+                      "fulfillment_id": "1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2b~Delhivery~3204dd9f-423a-46a7-8b94-f11642a83977~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "7500.72"
+                    },
+                    "lsp_provider_id": "Delhivery",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "3204dd9f-423a-46a7-8b94-f11642a83977",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "1",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Standard Delivery",
+                        "short_desc": "Delhivery Surface",
+                        "long_desc": "Delhivery Surface"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "7500.72"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P4D",
+                        "timestamp": "2025-04-28"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2c~P1~I1~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "59.00"
+                    },
+                    "lsp_provider_id": "P1",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "I1",
+                      "parent_item_id": "",
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "1",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "60 min delivery",
+                        "short_desc": "60 min delivery for F&B",
+                        "long_desc": "60 min delivery for F&B"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "59.00"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2023-06-06"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c2f~MOVERDELIVERY~I1~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "25527"
+                    },
+                    "lsp_provider_id": "MOVERDELIVERY",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "I1",
+                      "parent_item_id": "",
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "1",
+                      "descriptor": {
+                        "name": "30 min delivery",
+                        "short_desc": "30 min delivery for F&B",
+                        "long_desc": "30 min delivery for F&B",
+                        "code": "P2P"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "25527"
+                      },
+                      "time": {
+                        "duration": "PT30M",
+                        "label": "TAT",
+                        "timestamp": "2025-04-24T17:46:39.1265809Z"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c30~Bluedart Express~BDEEP0~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "1388.29"
+                    },
+                    "lsp_provider_id": "Bluedart Express",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "BDEEP0",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "1",
+                      "descriptor": {
+                        "name": "Dart Surface Etail",
+                        "code": "P2H2P",
+                        "short_desc": "Standard Delivery",
+                        "long_desc": "Standard Delivery"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "timestamp": "2025-04-28",
+                        "duration": "P4D"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "1388.29"
+                      },
+                      "parent_item_id": ""
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c31~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "815.00"
+                    },
+                    "lsp_provider_id": "DTDC",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "B2C SMART EXPRESS",
+                      "category_id": "Standard Delivery",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Standard Delivery",
+                        "short_desc": "B2C SMART EXPRESS",
+                        "long_desc": "3 - 4 Day/s"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "815.00"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P4D",
+                        "timestamp": "2025-04-28"
+                      },
+                      "fulfillment_id": "1"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c32~P1~I1~I1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "65560.00"
+                    },
+                    "lsp_provider_id": "P1",
+                    "lsp_fulfillment_id": "I1",
+                    "lsp_item_details": {
+                      "id": "I1",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "I1",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Standard",
+                        "short_desc": "Standard",
+                        "long_desc": "Standard"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "65560.00"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P8D",
+                        "timestamp": "2025-04-24T17:46:40.323020Z"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c27~I1~1~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c27~I1~1~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c27~I1~1~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c28~19537~YAARI-19537-20250424-U2JJE6IXS4~SY-1745516797923-51",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c28~19537~YAARI-19537-20250424-U2JJE6IXS4~SY-1745516797923-51",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c28~19537~YAARI-19537-20250424-U2JJE6IXS4~SY-1745516797923-51",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~a60ad63c-b760-42be-98e0-6022237da726",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~a60ad63c-b760-42be-98e0-6022237da726",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~a60ad63c-b760-42be-98e0-6022237da726",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2b~Delhivery~3204dd9f-423a-46a7-8b94-f11642a83977~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2b~Delhivery~3204dd9f-423a-46a7-8b94-f11642a83977~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2b~Delhivery~3204dd9f-423a-46a7-8b94-f11642a83977~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2c~P1~I1~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2c~P1~I1~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2c~P1~I1~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c2f~MOVERDELIVERY~I1~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c2f~MOVERDELIVERY~I1~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c2f~MOVERDELIVERY~I1~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c30~Bluedart Express~BDEEP0~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c30~Bluedart Express~BDEEP0~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c30~Bluedart Express~BDEEP0~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c31~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c31~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c31~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c32~P1~I1~I1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c32~P1~I1~I1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c32~P1~I1~I1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "ttl": "P1D"
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "accept_bap_terms",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_select",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "40b6f53d-ac0d-4739-ac1d-2408a3445482",
+            "timestamp": "2025-04-24T17:46:45.092Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "init_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745516858\",expires=\"1745520458\",headers=\"(created) (expires) digest\",signature=\"Jzed6xAVfNkyWrjcsi0jsnV4+y+W8CPxbPWyeL1jSamIDQg8e/NvhPJb10+KN7UXrY2v6dJzrfO8nqJ+SZC6AA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "8d7b23b7-d2e0-46ff-a9a6-c080930836da",
+            "timestamp": "2025-04-24T17:47:38.997Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f589b8f7-ed7d-4fa7-8bef-9c07e4697385",
+            "timestamp": "2025-04-24T17:47:39.218Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_init_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745516862\",expires=\"1745546862703\",headers=\"(created) (expires) digest\",signature=\"SPLrwT2Y9tndstV5Ui23ZqBJ7WIQS60UEz+9njUSGo7C+hHCj5bNv3kRv3LGIbevHZcz55dEVoIrbsGgxS+cBA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "8d7b23b7-d2e0-46ff-a9a6-c080930836da",
+            "timestamp": "2025-04-24T17:47:42.694Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "currency": "INR",
+                  "amount": "0"
+                },
+                "status": "NOT-PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "return_window_expiry",
+                "@ondc/org/settlement_window": "P2D",
+                "@ondc/org/withholding_amount": "0",
+                "@ondc/org/collected_by_status": "Assert",
+                "collected_by": "BPP"
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "8d7b23b7-d2e0-46ff-a9a6-c080930836da",
+            "timestamp": "2025-04-24T17:47:42.694Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "confirm_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745516875\",expires=\"1745520475\",headers=\"(created) (expires) digest\",signature=\"S0529JgBQnz2ms8HVamaFAiI0g1wAojFAaiPAN/sAJkXSGUwvZS38d9MnNAkI25ufNmEavG4FpvJYp+mQeSDCA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "confirm",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f7ab3502-9e65-44fb-a9c7-e2f8b150df53",
+            "timestamp": "2025-04-24T17:47:55.776Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "Created",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "person": {
+                      "name": "Nirdosh Chauhan"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                },
+                {
+                  "code": "bap_terms",
+                  "list": [
+                    {
+                      "code": "tax_number",
+                      "value": "00XYZAB1234C1Z8"
+                    },
+                    {
+                      "code": "accept_bpp_terms",
+                      "value": "Y"
+                    }
+                  ]
+                }
+              ],
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Assert",
+                "collected_by": "BAP"
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:47:55.776Z"
+            }
+          }
+        },
+        "response": {
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_confirm_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745516881\",expires=\"1745546881269\",headers=\"(created) (expires) digest\",signature=\"I9/+33Jfl2pFXhc6yeqvwnnVni+igJPZaU5d3i8vw7AE/oxndpdhTJ71kUXm9SHoK82bWsO3tKDsGR2OmPgJDA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f7ab3502-9e65-44fb-a9c7-e2f8b150df53",
+            "timestamp": "2025-04-24T17:48:01.262Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "Created",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T17:30:00.000Z",
+                        "end": "2025-04-24T19:30:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code",
+                      "long_desc": ""
+                    },
+                    "time": {
+                      "range": {
+                        "end": "2025-04-24T17:51:01.245Z"
+                      }
+                    }
+                  },
+                  "state": {
+                    "descriptor": {
+                      "code": "Pending",
+                      "name": "Getting ready for shipment (packaging)"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                },
+                {
+                  "code": "bap_terms",
+                  "list": [
+                    {
+                      "code": "tax_number",
+                      "value": "00XYZAB1234C1Z8"
+                    },
+                    {
+                      "code": "accept_bpp_terms",
+                      "value": "Y"
+                    }
+                  ]
+                }
+              ],
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Assert",
+                "collected_by": "BAP"
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:48:01.262Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f7ab3502-9e65-44fb-a9c7-e2f8b150df53",
+            "timestamp": "2025-04-24T17:48:01.262Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517220\",expires=\"1745547220121\",headers=\"(created) (expires) digest\",signature=\"+yWQsU8Y+FjzdLJ8at2F9iZ2GhavsUngnq9ZTLvIwJxdPHOeTB+XaPtqXX5RfN0EUxlsOi+xWm1EHknZGXeRAA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "6176f8bc-891e-4b23-8785-bf0536514039",
+            "timestamp": "2025-04-24T17:53:40.102Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "Accepted",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T17:30:00.000Z",
+                        "end": "2025-04-24T19:30:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code",
+                      "long_desc": ""
+                    },
+                    "time": {
+                      "range": {
+                        "end": "2025-04-24T17:51:01.245Z"
+                      }
+                    }
+                  },
+                  "state": {
+                    "descriptor": {
+                      "code": "Pending",
+                      "name": "Getting ready for shipment (packaging)"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "6176f8bc-891e-4b23-8785-bf0536514039",
+            "timestamp": "2025-04-24T17:53:40.102Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_2": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517229\",expires=\"1745547229038\",headers=\"(created) (expires) digest\",signature=\"CYE/3sCB7dXuoSsW5n+e83JuG5I4ObTYwosRK6qqPkqgPzufcsbdoYJM85zssBW/02peZUtgaxE/I4oPGt13Dg==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "ee0e53b0-dc1f-450f-b553-feca04d4ebde",
+            "timestamp": "2025-04-24T17:53:49.025Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Packed",
+                      "name": "Packaging completed. Ready to ship"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "ee0e53b0-dc1f-450f-b553-feca04d4ebde",
+            "timestamp": "2025-04-24T17:53:49.025Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_3": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517244\",expires=\"1745547244178\",headers=\"(created) (expires) digest\",signature=\"KEFJRTZNS+VgP/QdCyHyNbwfMkbTxlh2U4CEKHB3c6lBx8Pji9qrKbYfa08qVR55rhZRUwipYEvwkQtRx9g3Ag==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "7f56ff15-2533-4ba3-a9e3-c59ed0a5f759",
+            "timestamp": "2025-04-24T17:54:04.169Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Agent-assigned",
+                      "name": "Agent assigned"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "7f56ff15-2533-4ba3-a9e3-c59ed0a5f759",
+            "timestamp": "2025-04-24T17:54:04.169Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_4": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517247\",expires=\"1745547247177\",headers=\"(created) (expires) digest\",signature=\"0fxYHI6HsX7SGCzhueSvSZ+Trc40WeswVZYfD+yZoMHGwJtNsFJRhEPM/a5qy9cFbwbGx4PGz2A2Vvl8wr12Ag==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "1f4212dc-6b3c-4469-b161-fb85b860c145",
+            "timestamp": "2025-04-24T17:54:07.166Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-picked-up",
+                      "name": "Product picked up from the source and shipment started"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:07.007Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "1f4212dc-6b3c-4469-b161-fb85b860c145",
+            "timestamp": "2025-04-24T17:54:07.166Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_5": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517254\",expires=\"1745547254622\",headers=\"(created) (expires) digest\",signature=\"ItB/zR0JCdJxBgUG/dZnO5xQ7+0uul9dTEp2Vv08qFoXxQx5rqCZOmhOyLjXy9f0sROvFzrS0QVeP7nQ8dxbCQ==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "b7fde458-3c07-466a-9c52-a29cc17515ba",
+            "timestamp": "2025-04-24T17:54:14.614Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Out-for-delivery",
+                      "name": "Product would be delivered soon"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:07.007Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "b7fde458-3c07-466a-9c52-a29cc17515ba",
+            "timestamp": "2025-04-24T17:54:14.614Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "track_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745517265\",expires=\"1745520865\",headers=\"(created) (expires) digest\",signature=\"BVXdJVXK9cwfk/uZ6DWF0BI2luPJ26DlX71e3oCDG7eYl4E7flPezyGV0yTj3dlC6oy1vrGKg/C9PEARmuvUAA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "track",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "a3d30a32-0708-44c5-a646-ac14b38820af",
+            "timestamp": "2025-04-24T17:54:25.862Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order_id": "SS1745516875776"
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_track",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "5e2d673d-f5e6-4916-803d-1aebba93e932",
+            "timestamp": "2025-04-24T17:54:25.898Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_track_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517267\",expires=\"1745547267538\",headers=\"(created) (expires) digest\",signature=\"byeIqrTQw8pjhTCvgrQS9ykvdB7W3W9+ceZWvAkYxco0zB5iUZnExUPCF/zVEnxIFykmnAW5wYhyIH+f1QrqBw==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_track",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f7ab3502-9e65-44fb-a9c7-e2f8b150df53",
+            "timestamp": "2025-04-24T17:54:27.518Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "tracking": {
+              "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+              "url": "http://sequelstring-lsp-ondc.com/track",
+              "location": {
+                "gps": "12.974002,77.613458",
+                "time": {
+                  "timestamp": "2025-04-24T17:54:27.374Z"
+                },
+                "updated_at": "2025-04-24T17:54:27.374Z"
+              },
+              "status": "active",
+              "tags": [
+                {
+                  "code": "order",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "SS1745516875776"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "attr",
+                      "value": "tracking.location.gps"
+                    },
+                    {
+                      "code": "type",
+                      "value": "live_poll"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_track",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f7ab3502-9e65-44fb-a9c7-e2f8b150df53",
+            "timestamp": "2025-04-24T17:54:27.518Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_6": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517290\",expires=\"1745547290243\",headers=\"(created) (expires) digest\",signature=\"lXnxFQYfX/dBCFUXUA69SSnLRhszNlAo5N6vws/ndRiKsn8ntMLEFzIvpvctiLgQyby/h7yzgRgbibwjONJ/Ag==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "a023fe86-d0aa-4b8f-a1d2-fc74e0d4522a",
+            "timestamp": "2025-04-24T17:54:50.236Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Out-for-delivery",
+                      "name": "Product would be delivered soon"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:07.007Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "a023fe86-d0aa-4b8f-a1d2-fc74e0d4522a",
+            "timestamp": "2025-04-24T17:54:50.236Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_7": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517297\",expires=\"1745547297986\",headers=\"(created) (expires) digest\",signature=\"fis1epjkeNF7MqMAxogXugwv8fJSenz/o1MssLnxHOhRW5T4aep7/YxWU81vbo0wX7lOjG5UoEDAAruE7qH0AQ==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "7ca40130-bbbf-4d31-a104-bb4fe46b3ccd",
+            "timestamp": "2025-04-24T17:54:57.977Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "Completed",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-delivered",
+                      "name": "Product delivered"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:07.007Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:57.800Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Delivery",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "7ca40130-bbbf-4d31-a104-bb4fe46b3ccd",
+            "timestamp": "2025-04-24T17:54:57.977Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_8": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517304\",expires=\"1745547304831\",headers=\"(created) (expires) digest\",signature=\"/JNAYshtiEoFt5VbvqPBtsgArmsW53GSybybm/afCvE93jxKuFnuRTrVFpHWnFG9WsjnwSG0n6QONGHSNcReAA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "43e8cf4a-af4e-40c5-b91e-d58f5535f02a",
+            "timestamp": "2025-04-24T17:55:04.820Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-delivered",
+                      "name": "Product delivered"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:07.007Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:57.800Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Delivery",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "43e8cf4a-af4e-40c5-b91e-d58f5535f02a",
+            "timestamp": "2025-04-24T17:55:04.820Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "issue_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745517512\",expires=\"1745521112\",headers=\"(created) (expires) digest\",signature=\"HakTFZfgIl4qd6yzT7S10VQHJUzKBBywGmcRSDk+fbYOrbP0A8j5EkpcRhLc+tPCi8QoHIzxfnJyXhTMernXCA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "city": "std:080",
+            "country": "IND",
+            "core_version": "1.2.0",
+            "action": "issue",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "ttl": "PT30M",
+            "message_id": "cc9f1cd8-b3cf-4086-862d-3773db30afe1",
+            "timestamp": "2025-04-24T17:58:32.514Z"
+          },
+          "message": {
+            "issue": {
+              "id": "SS1745516712292",
+              "category": "ITEM",
+              "sub_category": "ITM03",
+              "complainant_info": {
+                "contact": {
+                  "email": "mail@ayushyadav.tech",
+                  "phone": "9990202525"
+                },
+                "person": {
+                  "name": "Ayush Yadav"
+                }
+              },
+              "order_details": {
+                "id": "SS1745516875776",
+                "state": "Created",
+                "provider_id": "674ecb33d7b9e10f4210d972",
+                "fulfillments": [
+                  {
+                    "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "state": "Pending"
+                  }
+                ],
+                "items": [
+                  {
+                    "id": "676a6179cac4860876a8e30b",
+                    "quantity": 2
+                  },
+                  {
+                    "id": "676a6126cac4860876a8e309",
+                    "quantity": 3
+                  }
+                ]
+              },
+              "description": {
+                "short_desc": "Some short description",
+                "long_desc": "Some long description",
+                "additional_desc": {
+                  "url": "https://ondc.org/assets/theme/images/ondc_registered_logo.svg?v=399788fda7",
+                  "content_type": "image/png"
+                },
+                "images": [
+                  "https://ondc.org/assets/theme/images/ondc_registered_logo.svg?v=399788fda7"
+                ]
+              },
+              "source": {
+                "network_participant_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+                "type": "CONSUMER"
+              },
+              "expected_response_time": {
+                "duration": "PT2H"
+              },
+              "expected_resolution_time": {
+                "duration": "P1D"
+              },
+              "status": "OPEN",
+              "issue_type": "ISSUE",
+              "issue_actions": {
+                "complainant_actions": [
+                  {
+                    "complainant_action": "OPEN",
+                    "short_desc": "Complaint created",
+                    "updated_at": "2025-04-24T17:58:32.513Z",
+                    "updated_by": {
+                      "org": {
+                        "name": "pramaan.ondc.org/beta/preprod/mock/buyer::ONDC:RET10"
+                      },
+                      "contact": {
+                        "phone": "9033891671",
+                        "email": "abc@ondc.in"
+                      },
+                      "person": {
+                        "name": "Support Desk"
+                      }
+                    }
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:58:32.513Z",
+              "updated_at": "2025-04-24T17:58:32.513Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "city": "std:080",
+            "country": "IND",
+            "core_version": "1.2.0",
+            "action": "issue",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "ttl": "PT30M",
+            "message_id": "cc9f1cd8-b3cf-4086-862d-3773db30afe1",
+            "timestamp": "2025-04-24T17:58:32.514Z"
+          },
+          "message": {
+            "ack": {
+              "status": "NACK"
+            }
+          },
+          "error": {
+            "type": "DOMAIN-ERROR",
+            "code": "30000",
+            "message": "Invalid request"
+          }
+        }
+      }
+    }
+  }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_confirm.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_confirm.json
@@ -1,0 +1,238 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "confirm",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "88e54322-2877-4d95-8d47-8840c205cc4f",
+          "timestamp": "2025-04-24T17:47:56.072Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "category_id": "Standard Delivery",
+                "descriptor": {
+                  "code": "P2P"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "id": "SS1745516875776",
+            "state": "Created",
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745516875776",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "tags": [
+              {
+                "code": "bap_terms",
+                "list": [
+                  {
+                    "code": "accept_bpp_terms",
+                    "value": "Y"
+                  }
+                ]
+              }
+            ],
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:47:56.027Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_init.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_init.json
@@ -1,0 +1,97 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "init",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "f589b8f7-ed7d-4fa7-8bef-9c07e4697385",
+          "timestamp": "2025-04-24T17:47:39.218Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "category_id": "Standard Delivery",
+                "descriptor": {
+                  "code": "P2P"
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_confirm.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_confirm.json
@@ -1,0 +1,240 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_confirm",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "88e54322-2877-4d95-8d47-8840c205cc4f",
+          "timestamp": "2025-04-24T17:47:56.118Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT10M"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "Accepted",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Pending"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745516875776",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:47:56.118Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_init.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_init.json
@@ -1,0 +1,102 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_init",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "f589b8f7-ed7d-4fa7-8bef-9c07e4697385",
+          "timestamp": "2025-04-24T17:47:39.253Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT10M"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                }
+              }
+            ],
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ],
+              "ttl": "P7D"
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_search.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_search.json
@@ -1,0 +1,414 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_search",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "7ca9ff7e-9c13-4762-af09-473143c2dbfb",
+          "timestamp": "2025-04-24T17:46:38.224Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT30S",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+        },
+        "message": {
+          "catalog": {
+            "bpp/descriptor": {
+              "name": "ONDC Pramaaan Logistics"
+            },
+            "bpp/providers": [
+              {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                "descriptor": {
+                  "name": "ONDC Pramaaan Logistics",
+                  "short_desc": "Swiftly Yours, Delivered with Care",
+                  "long_desc": "We deliver everywhere—yes, even Mars (just give us a little more rocket fuel)."
+                },
+                "categories": [
+                  {
+                    "id": "Standard Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "Immediate Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2025-04-24"
+                    }
+                  },
+                  {
+                    "id": "Express Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "Next Day Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "Same Day Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT4H",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                ],
+                "fulfillments": [
+                  {
+                    "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT15M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT20M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "a60ad63c-b760-42be-98e0-6022237da726",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT30M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT30M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT15M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "aed7bdf2-f09a-4e9e-8ed1-ba89731e519c",
+                    "type": "RTO"
+                  }
+                ],
+                "items": [
+                  {
+                    "id": "rto_std",
+                    "parent_item_id": "std_del",
+                    "category_id": "Standard Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "fulfillment_id": "aed7bdf2-f09a-4e9e-8ed1-ba89731e519c",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "rto_imd",
+                    "parent_item_id": "imd_del",
+                    "category_id": "Immediate Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Immediate Delivery",
+                      "long_desc": "Upto 60 mins for Delivery",
+                      "short_desc": "Upto 60 mins for Delivery"
+                    },
+                    "fulfillment_id": "aed7bdf2-f09a-4e9e-8ed1-ba89731e519c",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2025-04-24"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "imd_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Immediate Delivery",
+                      "long_desc": "Upto 60 mins for Delivery",
+                      "short_desc": "Upto 60 mins for Delivery"
+                    },
+                    "category_id": "Immediate Delivery",
+                    "fulfillment_id": "8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2025-04-24"
+                    }
+                  },
+                  {
+                    "id": "rto_exp",
+                    "parent_item_id": "exp_del",
+                    "category_id": "Express Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Express Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "fulfillment_id": "aed7bdf2-f09a-4e9e-8ed1-ba89731e519c",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "exp_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Express Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Express Delivery",
+                    "fulfillment_id": "a60ad63c-b760-42be-98e0-6022237da726",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "rto_nex",
+                    "parent_item_id": "nex_del",
+                    "category_id": "Next Day Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Next Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "fulfillment_id": "aed7bdf2-f09a-4e9e-8ed1-ba89731e519c",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "nex_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Next Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Next Day Delivery",
+                    "fulfillment_id": "a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "rto_same",
+                    "parent_item_id": "same_del",
+                    "category_id": "Same Day Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Same Day Delivery",
+                      "long_desc": "Same Delivery",
+                      "short_desc": "Same for Delivery"
+                    },
+                    "fulfillment_id": "aed7bdf2-f09a-4e9e-8ed1-ba89731e519c",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT4H",
+                      "timestamp": "2025-04-24"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "same_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Same Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Same Day Delivery",
+                    "fulfillment_id": "1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT4H",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_status_1_agent_assigned.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_status_1_agent_assigned.json
@@ -1,0 +1,253 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "a7e45dcd-8475-47f9-a116-fca6defb55c5",
+          "timestamp": "2025-04-24T17:54:04.004Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT50S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "In-progress",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Agent-assigned"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745516875776",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:54:04.004Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_status_2_picked_up.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_status_2_picked_up.json
@@ -1,0 +1,278 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "23e9aab1-0d67-4b30-a39d-47f7121e1225",
+          "timestamp": "2025-04-24T17:54:07.007Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT50S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "In-progress",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-picked-up"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:54:07.007Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "status": "NOT-PAID"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745516875776",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:54:07.007Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_status_3_out_for_delivery.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_status_3_out_for_delivery.json
@@ -1,0 +1,278 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "5f0b17a3-7feb-469e-a8c7-fa0df51f8145",
+          "timestamp": "2025-04-24T17:54:14.455Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT50S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "In-progress",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Out-for-delivery"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:54:07.007Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "status": "NOT-PAID"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745516875776",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:54:14.455Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_status_4_response.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_status_4_response.json
@@ -1,0 +1,278 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "c79086ea-9698-4530-a287-ab3f26fa5eff",
+          "timestamp": "2025-04-24T17:54:50.085Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT10M"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "In-progress",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Out-for-delivery"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:54:07.007Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "status": "NOT-PAID"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745516875776",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:54:14.455Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_status_5_delivered.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_status_5_delivered.json
@@ -1,0 +1,288 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "adeecf7a-a950-4d43-948a-6b6a458ef8bd",
+          "timestamp": "2025-04-24T17:54:57.800Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT50S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "Completed",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-delivered"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:54:07.007Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:54:57.800Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Delivery",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "status": "NOT-PAID",
+              "time": {
+                "timestamp": "2025-04-24T17:54:57.800Z"
+              }
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745516875776",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:54:57.800Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_status_6_response.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_status_6_response.json
@@ -1,0 +1,288 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "9584a9f7-a0f9-4ed2-9aaa-7e7b34f41b60",
+          "timestamp": "2025-04-24T17:55:04.604Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT10M"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "Completed",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-delivered"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:54:07.007Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:54:57.800Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Delivery",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "status": "NOT-PAID",
+              "time": {
+                "timestamp": "2025-04-24T17:54:57.800Z"
+              }
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745516875776",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:54:57.800Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_track.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_track.json
@@ -1,0 +1,55 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_track",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "5e2d673d-f5e6-4916-803d-1aebba93e932",
+          "timestamp": "2025-04-24T17:54:25.898Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "tracking": {
+            "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+            "url": "http://sequelstring-lsp-ondc.com/track",
+            "location": {
+              "gps": "12.974002,77.613458",
+              "time": {
+                "timestamp": "2025-04-24T17:54:27.374Z"
+              },
+              "updated_at": "2025-04-24T17:54:27.374Z"
+            },
+            "status": "active",
+            "tags": [
+              {
+                "code": "order",
+                "list": [
+                  {
+                    "code": "id",
+                    "value": "SS1745516875776"
+                  }
+                ]
+              },
+              {
+                "code": "config",
+                "list": [
+                  {
+                    "code": "attr",
+                    "value": "tracking.location.gps"
+                  },
+                  {
+                    "code": "type",
+                    "value": "live_poll"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_update.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_on_update.json
@@ -1,0 +1,246 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_update",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "5ea426da-4964-4e56-83e4-38389f631eac",
+          "timestamp": "2025-04-24T17:53:48.865Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT10M"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "Accepted",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Searching-for-Agent"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745516875776",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:47:56.118Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_search.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_search.json
@@ -1,0 +1,83 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "search",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "7ca9ff7e-9c13-4762-af09-473143c2dbfb",
+          "timestamp": "2025-04-24T17:46:37.155Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "intent": {
+            "category": {
+              "id": "Standard Delivery"
+            },
+            "provider": {
+              "time": {
+                "days": "1,2,3,4,5,6,7",
+                "schedule": {
+                  "holidays": []
+                },
+                "duration": "P0DT0H1M",
+                "range": {
+                  "start": "0001",
+                  "end": "2359"
+                }
+              }
+            },
+            "fulfillment": {
+              "type": "Delivery",
+              "start": {
+                "location": {
+                  "gps": "12.9263841,77.6654374",
+                  "address": {
+                    "area_code": "560103"
+                  }
+                }
+              },
+              "end": {
+                "location": {
+                  "gps": "28.4554726,77.0219019",
+                  "address": {
+                    "area_code": "122007"
+                  }
+                }
+              }
+            },
+            "payment": {
+              "type": "ON-ORDER"
+            },
+            "@ondc/org/payload_details": {
+              "weight": {
+                "unit": "gram",
+                "value": 1720
+              },
+              "dimensions": {
+                "length": {
+                  "unit": "centimeter",
+                  "value": 119
+                },
+                "breadth": {
+                  "unit": "centimeter",
+                  "value": 35
+                },
+                "height": {
+                  "unit": "centimeter",
+                  "value": 25
+                }
+              },
+              "category": "Grocery",
+              "value": {
+                "currency": "INR",
+                "value": "880"
+              },
+              "dangerous_goods": false
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_status_1_request.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_status_1_request.json
@@ -1,0 +1,20 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "c79086ea-9698-4530-a287-ab3f26fa5eff",
+          "timestamp": "2025-04-24T17:54:47.637Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order_id": "SS1745516875776"
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_status_2_request.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_status_2_request.json
@@ -1,0 +1,20 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "9584a9f7-a0f9-4ed2-9aaa-7e7b34f41b60",
+          "timestamp": "2025-04-24T17:55:03.137Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order_id": "SS1745516875776"
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_track.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_track.json
@@ -1,0 +1,20 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "track",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "5e2d673d-f5e6-4916-803d-1aebba93e932",
+          "timestamp": "2025-04-24T17:54:25.898Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order_id": "SS1745516875776"
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_update.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/LBNP_update.json
@@ -1,0 +1,90 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "update",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "5ea426da-4964-4e56-83e4-38389f631eac",
+          "timestamp": "2025-04-24T17:53:47.396Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "update_target": "fulfillment",
+          "order": {
+            "id": "SS1745516875776",
+            "state": "Created",
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "descriptor": {
+                  "code": "P2P"
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship",
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "updated_at": "2025-04-24T23:23:47.382Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_confirm.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_confirm.json
@@ -1,0 +1,335 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "confirm",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "f7ab3502-9e65-44fb-a9c7-e2f8b150df53",
+          "timestamp": "2025-04-24T17:47:55.776Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "Created",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D",
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": "other pickup confirmation code",
+                    "long_desc": "Pls pickup orders from counter number 01."
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "person": {
+                    "name": "Nirdosh Chauhan"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "tags": [
+              {
+                "code": "bpp_terms",
+                "list": [
+                  {
+                    "code": "np_type",
+                    "value": "MSN"
+                  },
+                  {
+                    "code": "collect_payment",
+                    "value": "Y"
+                  },
+                  {
+                    "code": "max_liability",
+                    "value": "2"
+                  },
+                  {
+                    "code": "max_liability_cap",
+                    "value": "10000"
+                  },
+                  {
+                    "code": "mandatory_arbitration",
+                    "value": "false"
+                  },
+                  {
+                    "code": "court_jurisdiction",
+                    "value": "Bengaluru"
+                  },
+                  {
+                    "code": "delay_interest",
+                    "value": "7"
+                  },
+                  {
+                    "code": "tax_number",
+                    "value": "29ABGCS7802J1ZX"
+                  },
+                  {
+                    "code": "provider_tax_number",
+                    "value": "ABGCS7802J"
+                  }
+                ]
+              },
+              {
+                "code": "bap_terms",
+                "list": [
+                  {
+                    "code": "tax_number",
+                    "value": "00XYZAB1234C1Z8"
+                  },
+                  {
+                    "code": "accept_bpp_terms",
+                    "value": "Y"
+                  }
+                ]
+              }
+            ],
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Assert",
+              "collected_by": "BAP"
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:47:55.776Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_init.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_init.json
@@ -1,0 +1,88 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "init",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "8d7b23b7-d2e0-46ff-a9a6-c080930836da",
+          "timestamp": "2025-04-24T17:47:38.997Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "ttl": "PT30S",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_confirm.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_confirm.json
@@ -1,0 +1,354 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_confirm",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "f7ab3502-9e65-44fb-a9c7-e2f8b150df53",
+          "timestamp": "2025-04-24T17:48:01.262Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "Created",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D",
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": "other pickup confirmation code",
+                    "long_desc": "Pls pickup orders from counter number 01."
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T17:30:00.000Z",
+                      "end": "2025-04-24T19:30:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "instructions": {
+                    "name": "Proof of delivery",
+                    "code": "3",
+                    "short_desc": "no delivery code",
+                    "long_desc": ""
+                  },
+                  "time": {
+                    "range": {
+                      "end": "2025-04-24T17:51:01.245Z"
+                    }
+                  }
+                },
+                "state": {
+                  "descriptor": {
+                    "code": "Pending",
+                    "name": "Getting ready for shipment (packaging)"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "tags": [
+              {
+                "code": "bpp_terms",
+                "list": [
+                  {
+                    "code": "np_type",
+                    "value": "MSN"
+                  },
+                  {
+                    "code": "collect_payment",
+                    "value": "Y"
+                  },
+                  {
+                    "code": "max_liability",
+                    "value": "2"
+                  },
+                  {
+                    "code": "max_liability_cap",
+                    "value": "10000"
+                  },
+                  {
+                    "code": "mandatory_arbitration",
+                    "value": "false"
+                  },
+                  {
+                    "code": "court_jurisdiction",
+                    "value": "Bengaluru"
+                  },
+                  {
+                    "code": "delay_interest",
+                    "value": "7"
+                  },
+                  {
+                    "code": "tax_number",
+                    "value": "29ABGCS7802J1ZX"
+                  },
+                  {
+                    "code": "provider_tax_number",
+                    "value": "ABGCS7802J"
+                  }
+                ]
+              },
+              {
+                "code": "bap_terms",
+                "list": [
+                  {
+                    "code": "tax_number",
+                    "value": "00XYZAB1234C1Z8"
+                  },
+                  {
+                    "code": "accept_bpp_terms",
+                    "value": "Y"
+                  }
+                ]
+              }
+            ],
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Assert",
+              "collected_by": "BAP"
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:48:01.262Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_init.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_init.json
@@ -1,0 +1,313 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_init",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "8d7b23b7-d2e0-46ff-a9a6-c080930836da",
+          "timestamp": "2025-04-24T17:47:42.694Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D",
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": "other pickup confirmation code",
+                    "long_desc": "Pls pickup orders from counter number 01."
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "currency": "INR",
+                "amount": "0"
+              },
+              "status": "NOT-PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "return_window_expiry",
+              "@ondc/org/settlement_window": "P2D",
+              "@ondc/org/withholding_amount": "0",
+              "@ondc/org/collected_by_status": "Assert",
+              "collected_by": "BPP"
+            },
+            "tags": [
+              {
+                "code": "bpp_terms",
+                "list": [
+                  {
+                    "code": "np_type",
+                    "value": "MSN"
+                  },
+                  {
+                    "code": "collect_payment",
+                    "value": "Y"
+                  },
+                  {
+                    "code": "max_liability",
+                    "value": "2"
+                  },
+                  {
+                    "code": "max_liability_cap",
+                    "value": "10000"
+                  },
+                  {
+                    "code": "mandatory_arbitration",
+                    "value": "false"
+                  },
+                  {
+                    "code": "court_jurisdiction",
+                    "value": "Bengaluru"
+                  },
+                  {
+                    "code": "delay_interest",
+                    "value": "7"
+                  },
+                  {
+                    "code": "tax_number",
+                    "value": "29ABGCS7802J1ZX"
+                  },
+                  {
+                    "code": "provider_tax_number",
+                    "value": "ABGCS7802J"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_search.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_search.json
@@ -1,0 +1,1396 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_search",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "d61a2ea2-d544-4d90-a3db-85be2ca13675",
+          "timestamp": "2025-04-24T17:45:24.651Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "ttl": "PT30S",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "catalog": {
+            "bpp/fulfillments": [
+              {
+                "id": "1",
+                "type": "Delivery",
+                "contact": {
+                  "phone": "9900025784",
+                  "email": "sgupta.scm@gmail.com"
+                }
+              }
+            ],
+            "bpp/descriptor": {
+              "name": "Lekhha",
+              "symbol": "https://lekhha.com/wp-content/uploads/2023/07/logo-light-1.png",
+              "short_desc": "App-based platform for order and inventory management.",
+              "long_desc": "LEKHHA is a simple solution to help you comprehensively run your business operations. Discover it to also track & manage your personal needs & resources. Reach out to us to serve you as your solution partner.",
+              "images": [
+                "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/logo",
+                "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/vendor",
+                "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/consumer",
+                "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/inventory"
+              ],
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    }
+                  ]
+                }
+              ]
+            },
+            "bpp/providers": [
+              {
+                "id": "674ecb33d7b9e10f4210d972",
+                "time": {
+                  "label": "enable",
+                  "timestamp": "2025-04-24T17:45:23.878Z"
+                },
+                "descriptor": {
+                  "name": "Lekhha Provider A",
+                  "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecb33d7b9e10f4210d972_S",
+                  "short_desc": "Lekhha_Seller_1 kyc short",
+                  "long_desc": "Lekhha_Seller_1 kyc long",
+                  "images": [
+                    "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecb33d7b9e10f4210d972"
+                  ]
+                },
+                "ttl": "P1D",
+                "creds": [
+                  {
+                    "descriptor": {
+                      "code": "Lekhha_Seller_1_cred1",
+                      "name": "Lekhha_Seller_1 cred1",
+                      "short_desc": "Lekhha_Seller_1 cred1 short"
+                    },
+                    "id": "674ecbc6d7b9e10f4210d973_1",
+                    "tags": [
+                      {
+                        "code": "verification",
+                        "list": [
+                          {
+                            "code": "verify_url",
+                            "value": "https://url1url.com/verify1"
+                          },
+                          {
+                            "code": "valid_from",
+                            "value": "2024-12-09T00:00:00.000Z"
+                          },
+                          {
+                            "code": "valid_to",
+                            "value": "2027-03-31T00:00:00.000Z"
+                          }
+                        ]
+                      }
+                    ],
+                    "url": "https://url1url.com"
+                  }
+                ],
+                "fulfillments": [
+                  {
+                    "id": "1",
+                    "type": "Delivery",
+                    "contact": {
+                      "phone": "9900025784",
+                      "email": "sgupta.scm@gmail.com"
+                    }
+                  }
+                ],
+                "tags": [
+                  {
+                    "code": "order_value",
+                    "list": [
+                      {
+                        "code": "min_value",
+                        "value": "150.5"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "timing",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "Order"
+                      },
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "day_from",
+                        "value": "1"
+                      },
+                      {
+                        "code": "day_to",
+                        "value": "7"
+                      },
+                      {
+                        "code": "time_from",
+                        "value": "0001"
+                      },
+                      {
+                        "code": "time_to",
+                        "value": "2359"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "timing",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "Delivery"
+                      },
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "day_from",
+                        "value": "1"
+                      },
+                      {
+                        "code": "day_to",
+                        "value": "7"
+                      },
+                      {
+                        "code": "time_from",
+                        "value": "0001"
+                      },
+                      {
+                        "code": "time_to",
+                        "value": "2359"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "timing",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "Self-Pickup"
+                      },
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "day_from",
+                        "value": "1"
+                      },
+                      {
+                        "code": "day_to",
+                        "value": "7"
+                      },
+                      {
+                        "code": "time_from",
+                        "value": "0001"
+                      },
+                      {
+                        "code": "time_to",
+                        "value": "2359"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "serviceability",
+                    "list": [
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "category",
+                        "value": "Bakery, Cakes & Dairy"
+                      },
+                      {
+                        "code": "type",
+                        "value": "11"
+                      },
+                      {
+                        "code": "val",
+                        "value": "100000-999999"
+                      },
+                      {
+                        "code": "unit",
+                        "value": "pincode"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "serviceability",
+                    "list": [
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "category",
+                        "value": "Energy and Soft Drinks"
+                      },
+                      {
+                        "code": "type",
+                        "value": "11"
+                      },
+                      {
+                        "code": "val",
+                        "value": "100000-999999"
+                      },
+                      {
+                        "code": "unit",
+                        "value": "pincode"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "serviceability",
+                    "list": [
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "category",
+                        "value": "Fruits and Vegetables"
+                      },
+                      {
+                        "code": "type",
+                        "value": "11"
+                      },
+                      {
+                        "code": "val",
+                        "value": "100000-999999"
+                      },
+                      {
+                        "code": "unit",
+                        "value": "pincode"
+                      }
+                    ]
+                  }
+                ],
+                "items": [
+                  {
+                    "id": "676a61f6cac4860876a8e30f",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:45:24.155Z"
+                    },
+                    "parent_item_id": "V10000000001",
+                    "descriptor": {
+                      "name": "Milk orange",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Milk orange short",
+                      "long_desc": "Milk orange long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e3_0"
+                      ],
+                      "code": "1:1000000000232"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "13"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "49.82",
+                      "maximum_value": "53.00"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 11",
+                      "additives_info": "additives info 11",
+                      "brand_owner_FSSAI_license_no": "fssai license 11",
+                      "other_FSSAI_license_no": "other license 11",
+                      "importer_FSSAI_license_no": "importer license 11"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 11",
+                      "manufacturer_or_packer_address": "address 11",
+                      "common_or_generic_name_of_commodity": "commodity 11",
+                      "month_year_of_manufacture_packing_import": "year 11"
+                    }
+                  },
+                  {
+                    "id": "676a6179cac4860876a8e30b",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:45:24.185Z"
+                    },
+                    "parent_item_id": "V10000000002",
+                    "descriptor": {
+                      "name": "Milk blue",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Milk blue short",
+                      "long_desc": "Milk blue long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e5_0"
+                      ],
+                      "code": "1:1000000000233"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "10"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "12"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.00",
+                      "maximum_value": "400.00"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 9",
+                      "additives_info": "additives info 9",
+                      "brand_owner_FSSAI_license_no": "fssai license 9",
+                      "other_FSSAI_license_no": "other license 9",
+                      "importer_FSSAI_license_no": "importer license 9"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 9",
+                      "manufacturer_or_packer_address": "address 9",
+                      "common_or_generic_name_of_commodity": "commodity 9",
+                      "month_year_of_manufacture_packing_import": "year 9"
+                    }
+                  },
+                  {
+                    "id": "676a6260cac4860876a8e311",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:45:24.217Z"
+                    },
+                    "parent_item_id": "V10000000001",
+                    "descriptor": {
+                      "name": "Milk orange",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Milk orange short",
+                      "long_desc": "Milk orange long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e7_0"
+                      ],
+                      "code": "1:1000000000234"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "10"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "14"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "500.00",
+                      "maximum_value": "500.00"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 12",
+                      "additives_info": "additives info 12",
+                      "brand_owner_FSSAI_license_no": "fssai license 12",
+                      "other_FSSAI_license_no": "other license 12",
+                      "importer_FSSAI_license_no": "importer license 12"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 12",
+                      "manufacturer_or_packer_address": "address 12",
+                      "common_or_generic_name_of_commodity": "commodity 12",
+                      "month_year_of_manufacture_packing_import": "year 12"
+                    }
+                  },
+                  {
+                    "id": "676cf465e5eb3c28a8741e99",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:45:24.313Z"
+                    },
+                    "descriptor": {
+                      "name": "Pista milk",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Pista milk short",
+                      "long_desc": "Pista milk long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd72c_0"
+                      ],
+                      "code": "1:1000000000240"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "32"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "18.50",
+                      "maximum_value": "20.00"
+                    },
+                    "category_id": "Energy and Soft Drinks",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 18",
+                      "additives_info": "additives info 18",
+                      "brand_owner_FSSAI_license_no": "fssai license 18",
+                      "other_FSSAI_license_no": "other license 18",
+                      "importer_FSSAI_license_no": "importer license 18"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 18",
+                      "manufacturer_or_packer_address": "address 18",
+                      "common_or_generic_name_of_commodity": "commodity 18",
+                      "month_year_of_manufacture_packing_import": "year 18"
+                    }
+                  },
+                  {
+                    "id": "676cf465e5eb3c28a8741e9a",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:45:24.332Z"
+                    },
+                    "descriptor": {
+                      "name": "Mango milk",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Mango milk short",
+                      "long_desc": "Mango milk long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd72e_0"
+                      ],
+                      "code": "1:1000000000241"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "33"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "20.16",
+                      "maximum_value": "21.80"
+                    },
+                    "category_id": "Energy and Soft Drinks",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 7",
+                      "additives_info": "additives info 7",
+                      "brand_owner_FSSAI_license_no": "fssai license 7",
+                      "other_FSSAI_license_no": "other license 7",
+                      "importer_FSSAI_license_no": "importer license 7"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 7",
+                      "manufacturer_or_packer_address": "address 7",
+                      "common_or_generic_name_of_commodity": "commodity 7",
+                      "month_year_of_manufacture_packing_import": "year 7"
+                    }
+                  },
+                  {
+                    "id": "676cf465e5eb3c28a8741e9b",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:45:24.349Z"
+                    },
+                    "descriptor": {
+                      "name": "Vanilla milk",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Vanilla milk short",
+                      "long_desc": "Vanilla milk long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd730_0"
+                      ],
+                      "code": "1:1000000000242"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "35"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "18.51",
+                      "maximum_value": "20.01"
+                    },
+                    "category_id": "Energy and Soft Drinks",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 19",
+                      "additives_info": "additives info 19",
+                      "brand_owner_FSSAI_license_no": "fssai license 19",
+                      "other_FSSAI_license_no": "other license 19",
+                      "importer_FSSAI_license_no": "importer license 19"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer name 19",
+                      "manufacturer_or_packer_address": "packer address 19",
+                      "common_or_generic_name_of_commodity": "generic name 19",
+                      "month_year_of_manufacture_packing_import": "month year 19"
+                    }
+                  },
+                  {
+                    "id": "676a5f87cac4860876a8e2ff",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:45:24.362Z"
+                    },
+                    "descriptor": {
+                      "name": "Butter",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Butter short",
+                      "long_desc": "Butter long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd736_0"
+                      ],
+                      "code": "1:1000000000245"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "gram",
+                          "value": "200"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "23"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "109.38",
+                      "maximum_value": "124.30"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 3",
+                      "additives_info": "additives info 3",
+                      "brand_owner_FSSAI_license_no": "fssai license 3",
+                      "other_FSSAI_license_no": "other license 3",
+                      "importer_FSSAI_license_no": "importer license 3"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 13",
+                      "manufacturer_or_packer_address": "address 13",
+                      "common_or_generic_name_of_commodity": "commodity 13",
+                      "month_year_of_manufacture_packing_import": "year 13"
+                    }
+                  },
+                  {
+                    "id": "676a5f11cac4860876a8e2fb",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:45:24.373Z"
+                    },
+                    "descriptor": {
+                      "name": "Burfi",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Burfi short",
+                      "long_desc": "Burfi long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd73a_0"
+                      ],
+                      "code": "1:1000000000247"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "gram",
+                          "value": "200"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "22"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "71.20",
+                      "maximum_value": "80.00"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 2",
+                      "additives_info": "additives info 2",
+                      "brand_owner_FSSAI_license_no": "fssai license 2",
+                      "other_FSSAI_license_no": "other license 2",
+                      "importer_FSSAI_license_no": "importer license 2"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer name 2",
+                      "manufacturer_or_packer_address": "packer address 2",
+                      "common_or_generic_name_of_commodity": "commodity 2",
+                      "month_year_of_manufacture_packing_import": "packing import 2"
+                    }
+                  },
+                  {
+                    "id": "676aab3800d7d9212e3ba074",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:45:24.386Z"
+                    },
+                    "descriptor": {
+                      "name": "Watermelon",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Watermelon short",
+                      "long_desc": "Watermelon long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd740_0"
+                      ],
+                      "code": "1:2000000000349"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "kilogram",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "46"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "45.00",
+                      "maximum_value": "45.00"
+                    },
+                    "category_id": "Fruits and Vegetables",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M"
+                  },
+                  {
+                    "id": "676a9e1d00d7d9212e3b8f7f",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:45:24.401Z"
+                    },
+                    "descriptor": {
+                      "name": "Apple",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Apple short",
+                      "long_desc": "Apple long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd742_0"
+                      ],
+                      "code": "1:2000000000341"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "kilogram",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "21"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.02",
+                      "maximum_value": "120.02"
+                    },
+                    "category_id": "Fruits and Vegetables",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M"
+                  },
+                  {
+                    "id": "676aaa5700d7d9212e3ba019",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:45:24.412Z"
+                    },
+                    "descriptor": {
+                      "name": "Papaya",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Papaya short",
+                      "long_desc": "Papaya long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd746_0"
+                      ],
+                      "code": "1:2000000000346"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "kilogram",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "29"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "61.28",
+                      "maximum_value": "64.50"
+                    },
+                    "category_id": "Fruits and Vegetables",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M"
+                  },
+                  {
+                    "id": "676a9fa200d7d9212e3b8fbd",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:45:24.427Z"
+                    },
+                    "descriptor": {
+                      "name": "Beetroot",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Beetroot short",
+                      "long_desc": "Beetroot long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6762dbb841c7aa7c86d1d1c2_0"
+                      ],
+                      "code": "1:2000000000343"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "kilogram",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "0"
+                      },
+                      "maximum": {
+                        "count": "6"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "30.00",
+                      "maximum_value": "30.00"
+                    },
+                    "category_id": "Fruits and Vegetables",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M"
+                  },
+                  {
+                    "id": "676a9f7800d7d9212e3b8fbb",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:45:24.438Z"
+                    },
+                    "descriptor": {
+                      "name": "Beans haricot",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Beans haricot short",
+                      "long_desc": "Beans haricot long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6762dbb841c7aa7c86d1d1c4_0"
+                      ],
+                      "code": "1:2000000000342"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "kilogram",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "0"
+                      },
+                      "maximum": {
+                        "count": "5"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "76.42",
+                      "maximum_value": "78.38"
+                    },
+                    "category_id": "Fruits and Vegetables",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M"
+                  },
+                  {
+                    "id": "676a6126cac4860876a8e309",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:45:24.519Z"
+                    },
+                    "parent_item_id": "V10000000002",
+                    "descriptor": {
+                      "name": "Milk blue",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Milk blue short",
+                      "long_desc": "Milk blue long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e1_0"
+                      ],
+                      "code": "1:1000000000231"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "11"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00",
+                      "maximum_value": "40.00"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 8",
+                      "additives_info": "additives info 8",
+                      "brand_owner_FSSAI_license_no": "fssai license 8",
+                      "other_FSSAI_license_no": "other license 8",
+                      "importer_FSSAI_license_no": "importer license 8"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 8",
+                      "manufacturer_or_packer_address": "address 8",
+                      "common_or_generic_name_of_commodity": "commodity 8",
+                      "month_year_of_manufacture_packing_import": "year 8"
+                    }
+                  }
+                ],
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:45:23.899Z",
+                      "days": "1,2,3,4,5,6,7",
+                      "schedule": {
+                        "holidays": []
+                      },
+                      "range": {
+                        "start": "0001",
+                        "end": "2359"
+                      }
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "locality": "Bengaluru",
+                      "street": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "city": "Bengaluru",
+                      "area_code": "560103",
+                      "state": "KA"
+                    },
+                    "circle": {
+                      "gps": "12.9263841,77.6654374",
+                      "radius": {
+                        "unit": "km",
+                        "value": "999"
+                      }
+                    }
+                  }
+                ],
+                "categories": [
+                  {
+                    "id": "V10000000001",
+                    "descriptor": {
+                      "name": "Variant Group 10000000001"
+                    },
+                    "tags": [
+                      {
+                        "code": "type",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "variant_group"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "attr",
+                        "list": [
+                          {
+                            "code": "name",
+                            "value": "item.quantity.unitized.measure"
+                          },
+                          {
+                            "code": "seq",
+                            "value": "1"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "V10000000002",
+                    "descriptor": {
+                      "name": "Variant Group 10000000002"
+                    },
+                    "tags": [
+                      {
+                        "code": "type",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "variant_group"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "attr",
+                        "list": [
+                          {
+                            "code": "name",
+                            "value": "item.quantity.unitized.measure"
+                          },
+                          {
+                            "code": "seq",
+                            "value": "1"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_select.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_select.json
@@ -1,0 +1,1906 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_select",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "40b6f53d-ac0d-4739-ac1d-2408a3445482",
+          "timestamp": "2025-04-24T17:46:45.092Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "id": "676a6179cac4860876a8e30b",
+                "quantity": {
+                  "count": 2
+                }
+              },
+              {
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "id": "676a6126cac4860876a8e309",
+                "quantity": {
+                  "count": 3
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "680a78fe48665475e6bf8c27~I1~1~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Ecom Express Limited",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P5D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a78fe48665475e6bf8c28~19537~YAARI-19537-20250424-U2JJE6IXS4~SY-1745516797923-51",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Ecom Express",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate~ns_immediate_f1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "NS_LSP",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "PT55M",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "NS_LSP",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "PT55M",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Immediate Delivery",
+                "@ondc/org/TAT": "PT60M",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~a60ad63c-b760-42be-98e0-6022237da726",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Express Delivery",
+                "@ondc/org/TAT": "P1D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Next Day Delivery",
+                "@ondc/org/TAT": "P1D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Same Day Delivery",
+                "@ondc/org/TAT": "PT4H",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a78fe48665475e6bf8c2b~Delhivery~3204dd9f-423a-46a7-8b94-f11642a83977~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Delhivery",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P4D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a78fe48665475e6bf8c2c~P1~I1~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Bharat Mart",
+                "tracking": false,
+                "@ondc/org/category": "Immediate Delivery",
+                "@ondc/org/TAT": "PT60M",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a78ff48665475e6bf8c2f~MOVERDELIVERY~I1~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Mover",
+                "tracking": false,
+                "@ondc/org/category": "Immediate Delivery",
+                "@ondc/org/TAT": "PT30M",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a78ff48665475e6bf8c30~Bluedart Express~BDEEP0~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Bluedart Express",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P4D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a790048665475e6bf8c31~DTDC~B2C SMART EXPRESS~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "DTDC",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P4D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a790048665475e6bf8c32~P1~I1~I1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Exeed Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P8D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "129831.05"
+              },
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "quantity": {
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "12"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "quantity": {
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "11"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c27~I1~1~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "69"
+                  },
+                  "lsp_provider_id": "I1",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "1",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "name": "Standard Delivery",
+                      "code": "P2H2P",
+                      "short_desc": "Fast Delivery For Items",
+                      "long_desc": "Fast Delivery for Items"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "1",
+                    "price": {
+                      "currency": "INR",
+                      "value": "69"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "timestamp": "2025-04-28",
+                      "duration": "P5D"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c28~19537~YAARI-19537-20250424-U2JJE6IXS4~SY-1745516797923-51",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "395.74"
+                  },
+                  "lsp_provider_id": "19537",
+                  "lsp_fulfillment_id": "SY-1745516797923-51",
+                  "lsp_item_details": {
+                    "id": "YAARI-19537-20250424-U2JJE6IXS4",
+                    "parent_item_id": "",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "SY-1745516797923-51",
+                    "descriptor": {
+                      "code": "P2H2P",
+                      "name": "Ecom Express",
+                      "short_desc": "Ecom Express",
+                      "long_desc": "Ecom Express"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "395.74"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "2.0"
+                  },
+                  "lsp_provider_id": "NS_LSP",
+                  "lsp_fulfillment_id": "ns_immediate_f1",
+                  "lsp_item_details": {
+                    "id": "ns_immediate",
+                    "parent_item_id": "",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "ns_immediate_f1",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "NS LSP Immediate Delivery",
+                      "short_desc": "Immediate Delivery by NS LSP",
+                      "long_desc": "Immediate Delivery by NS LSP"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2.0"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT55M",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  },
+                  "lsp_provider_id": "NS_LSP",
+                  "lsp_fulfillment_id": "ns_immediate_f1-RTO",
+                  "lsp_item_details": {
+                    "id": "ns_immediate-RTO",
+                    "parent_item_id": "ns_immediate",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "ns_immediate_f1-RTO",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "RTO quote",
+                      "short_desc": "RTO quote",
+                      "long_desc": "RTO quote"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT55M",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                  "lsp_item_details": {
+                    "id": "imd_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Immediate Delivery",
+                      "long_desc": "Upto 60 mins for Delivery",
+                      "short_desc": "Upto 60 mins for Delivery"
+                    },
+                    "category_id": "Immediate Delivery",
+                    "fulfillment_id": "8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~a60ad63c-b760-42be-98e0-6022237da726",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "a60ad63c-b760-42be-98e0-6022237da726",
+                  "lsp_item_details": {
+                    "id": "exp_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Express Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Express Delivery",
+                    "fulfillment_id": "a60ad63c-b760-42be-98e0-6022237da726",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                  "lsp_item_details": {
+                    "id": "nex_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Next Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Next Day Delivery",
+                    "fulfillment_id": "a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                  "lsp_item_details": {
+                    "id": "same_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Same Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Same Day Delivery",
+                    "fulfillment_id": "1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT4H",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2b~Delhivery~3204dd9f-423a-46a7-8b94-f11642a83977~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "7500.72"
+                  },
+                  "lsp_provider_id": "Delhivery",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "3204dd9f-423a-46a7-8b94-f11642a83977",
+                    "parent_item_id": "",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "1",
+                    "descriptor": {
+                      "code": "P2H2P",
+                      "name": "Standard Delivery",
+                      "short_desc": "Delhivery Surface",
+                      "long_desc": "Delhivery Surface"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "7500.72"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P4D",
+                      "timestamp": "2025-04-28"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2c~P1~I1~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "59.00"
+                  },
+                  "lsp_provider_id": "P1",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "I1",
+                    "parent_item_id": "",
+                    "category_id": "Immediate Delivery",
+                    "fulfillment_id": "1",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "60 min delivery",
+                      "short_desc": "60 min delivery for F&B",
+                      "long_desc": "60 min delivery for F&B"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "59.00"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2023-06-06"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78ff48665475e6bf8c2f~MOVERDELIVERY~I1~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "25527"
+                  },
+                  "lsp_provider_id": "MOVERDELIVERY",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "I1",
+                    "parent_item_id": "",
+                    "category_id": "Immediate Delivery",
+                    "fulfillment_id": "1",
+                    "descriptor": {
+                      "name": "30 min delivery",
+                      "short_desc": "30 min delivery for F&B",
+                      "long_desc": "30 min delivery for F&B",
+                      "code": "P2P"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "25527"
+                    },
+                    "time": {
+                      "duration": "PT30M",
+                      "label": "TAT",
+                      "timestamp": "2025-04-24T17:46:39.1265809Z"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78ff48665475e6bf8c30~Bluedart Express~BDEEP0~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "1388.29"
+                  },
+                  "lsp_provider_id": "Bluedart Express",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "BDEEP0",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "1",
+                    "descriptor": {
+                      "name": "Dart Surface Etail",
+                      "code": "P2H2P",
+                      "short_desc": "Standard Delivery",
+                      "long_desc": "Standard Delivery"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "timestamp": "2025-04-28",
+                      "duration": "P4D"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "1388.29"
+                    },
+                    "parent_item_id": ""
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a790048665475e6bf8c31~DTDC~B2C SMART EXPRESS~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "815.00"
+                  },
+                  "lsp_provider_id": "DTDC",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "B2C SMART EXPRESS",
+                    "category_id": "Standard Delivery",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2H2P",
+                      "name": "Standard Delivery",
+                      "short_desc": "B2C SMART EXPRESS",
+                      "long_desc": "3 - 4 Day/s"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "815.00"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P4D",
+                      "timestamp": "2025-04-28"
+                    },
+                    "fulfillment_id": "1"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a790048665475e6bf8c32~P1~I1~I1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "65560.00"
+                  },
+                  "lsp_provider_id": "P1",
+                  "lsp_fulfillment_id": "I1",
+                  "lsp_item_details": {
+                    "id": "I1",
+                    "parent_item_id": "",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "I1",
+                    "descriptor": {
+                      "code": "P2H2P",
+                      "name": "Standard",
+                      "short_desc": "Standard",
+                      "long_desc": "Standard"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "65560.00"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P8D",
+                      "timestamp": "2025-04-24T17:46:40.323020Z"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c27~I1~1~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c27~I1~1~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c27~I1~1~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c28~19537~YAARI-19537-20250424-U2JJE6IXS4~SY-1745516797923-51",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c28~19537~YAARI-19537-20250424-U2JJE6IXS4~SY-1745516797923-51",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c28~19537~YAARI-19537-20250424-U2JJE6IXS4~SY-1745516797923-51",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~a60ad63c-b760-42be-98e0-6022237da726",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~a60ad63c-b760-42be-98e0-6022237da726",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~a60ad63c-b760-42be-98e0-6022237da726",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2b~Delhivery~3204dd9f-423a-46a7-8b94-f11642a83977~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2b~Delhivery~3204dd9f-423a-46a7-8b94-f11642a83977~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2b~Delhivery~3204dd9f-423a-46a7-8b94-f11642a83977~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2c~P1~I1~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2c~P1~I1~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2c~P1~I1~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78ff48665475e6bf8c2f~MOVERDELIVERY~I1~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78ff48665475e6bf8c2f~MOVERDELIVERY~I1~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78ff48665475e6bf8c2f~MOVERDELIVERY~I1~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78ff48665475e6bf8c30~Bluedart Express~BDEEP0~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78ff48665475e6bf8c30~Bluedart Express~BDEEP0~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78ff48665475e6bf8c30~Bluedart Express~BDEEP0~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a790048665475e6bf8c31~DTDC~B2C SMART EXPRESS~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a790048665475e6bf8c31~DTDC~B2C SMART EXPRESS~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a790048665475e6bf8c31~DTDC~B2C SMART EXPRESS~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a790048665475e6bf8c32~P1~I1~I1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a790048665475e6bf8c32~P1~I1~I1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a790048665475e6bf8c32~P1~I1~I1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "ttl": "P1D"
+            },
+            "tags": [
+              {
+                "code": "bpp_terms",
+                "list": [
+                  {
+                    "code": "accept_bap_terms",
+                    "value": "Y"
+                  },
+                  {
+                    "code": "np_type",
+                    "value": "MSN"
+                  },
+                  {
+                    "code": "collect_payment",
+                    "value": "Y"
+                  },
+                  {
+                    "code": "max_liability",
+                    "value": "2"
+                  },
+                  {
+                    "code": "max_liability_cap",
+                    "value": "10000"
+                  },
+                  {
+                    "code": "mandatory_arbitration",
+                    "value": "false"
+                  },
+                  {
+                    "code": "court_jurisdiction",
+                    "value": "Bengaluru"
+                  },
+                  {
+                    "code": "delay_interest",
+                    "value": "7"
+                  },
+                  {
+                    "code": "tax_number",
+                    "value": "29ABGCS7802J1ZX"
+                  },
+                  {
+                    "code": "provider_tax_number",
+                    "value": "ABGCS7802J"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_1_accepted.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_1_accepted.json
@@ -1,0 +1,312 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "6176f8bc-891e-4b23-8785-bf0536514039",
+          "timestamp": "2025-04-24T17:53:40.102Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "Accepted",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D",
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": "other pickup confirmation code",
+                    "long_desc": "Pls pickup orders from counter number 01."
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T17:30:00.000Z",
+                      "end": "2025-04-24T19:30:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "instructions": {
+                    "name": "Proof of delivery",
+                    "code": "3",
+                    "short_desc": "no delivery code",
+                    "long_desc": ""
+                  },
+                  "time": {
+                    "range": {
+                      "end": "2025-04-24T17:51:01.245Z"
+                    }
+                  }
+                },
+                "state": {
+                  "descriptor": {
+                    "code": "Pending",
+                    "name": "Getting ready for shipment (packaging)"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:53:40.032Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_2_packed.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_2_packed.json
@@ -1,0 +1,294 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "ee0e53b0-dc1f-450f-b553-feca04d4ebde",
+          "timestamp": "2025-04-24T17:53:49.025Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Packed",
+                    "name": "Packaging completed. Ready to ship"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:53:40.032Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_3_agent_assigned.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_3_agent_assigned.json
@@ -1,0 +1,302 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "7f56ff15-2533-4ba3-a9e3-c59ed0a5f759",
+          "timestamp": "2025-04-24T17:54:04.169Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Agent-assigned",
+                    "name": "Agent assigned"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:53:40.032Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_4_picked_up.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_4_picked_up.json
@@ -1,0 +1,309 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "1f4212dc-6b3c-4469-b161-fb85b860c145",
+          "timestamp": "2025-04-24T17:54:07.166Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-picked-up",
+                    "name": "Product picked up from the source and shipment started"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:54:07.007Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:53:40.032Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_5_out_for_delivery.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_5_out_for_delivery.json
@@ -1,0 +1,309 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "b7fde458-3c07-466a-9c52-a29cc17515ba",
+          "timestamp": "2025-04-24T17:54:14.614Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Out-for-delivery",
+                    "name": "Product would be delivered soon"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:54:07.007Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:53:40.032Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_6_response.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_6_response.json
@@ -1,0 +1,309 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "a023fe86-d0aa-4b8f-a1d2-fc74e0d4522a",
+          "timestamp": "2025-04-24T17:54:50.236Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Out-for-delivery",
+                    "name": "Product would be delivered soon"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:54:07.007Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:53:40.032Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_7_delivered.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_7_delivered.json
@@ -1,0 +1,316 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "7ca40130-bbbf-4d31-a104-bb4fe46b3ccd",
+          "timestamp": "2025-04-24T17:54:57.977Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "Completed",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-delivered",
+                    "name": "Product delivered"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:54:07.007Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:54:57.800Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Delivery",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:53:40.032Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_8_response.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_status_8_response.json
@@ -1,0 +1,316 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "43e8cf4a-af4e-40c5-b91e-d58f5535f02a",
+          "timestamp": "2025-04-24T17:55:04.820Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745516875776",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:47:38.997Z",
+              "updated_at": "2025-04-24T17:47:38.997Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-delivered",
+                    "name": "Product delivered"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:54:07.007Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:54:57.800Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Delivery",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:47:55.776Z",
+            "updated_at": "2025-04-24T17:53:40.032Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_track.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_on_track.json
@@ -1,0 +1,54 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_track",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "f7ab3502-9e65-44fb-a9c7-e2f8b150df53",
+          "timestamp": "2025-04-24T17:54:27.518Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "tracking": {
+            "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+            "url": "http://sequelstring-lsp-ondc.com/track",
+            "location": {
+              "gps": "12.974002,77.613458",
+              "time": {
+                "timestamp": "2025-04-24T17:54:27.374Z"
+              },
+              "updated_at": "2025-04-24T17:54:27.374Z"
+            },
+            "status": "active",
+            "tags": [
+              {
+                "code": "order",
+                "list": [
+                  {
+                    "code": "id",
+                    "value": "SS1745516875776"
+                  }
+                ]
+              },
+              {
+                "code": "config",
+                "list": [
+                  {
+                    "code": "attr",
+                    "value": "tracking.location.gps"
+                  },
+                  {
+                    "code": "type",
+                    "value": "live_poll"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_search.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_search.json
@@ -1,0 +1,34 @@
+    {
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "search",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "d61a2ea2-d544-4d90-a3db-85be2ca13675",
+          "timestamp": "2025-04-24T17:45:20.418Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "intent": {
+            "payment": {
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3"
+            },
+            "tags": [
+              {
+                "code": "catalog_full",
+                "list": [
+                  {
+                    "code": "payload_type",
+                    "value": "inline"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+    }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_select.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_select.json
@@ -1,0 +1,60 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "select",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "40b6f53d-ac0d-4739-ac1d-2408a3445482",
+          "timestamp": "2025-04-24T17:46:36.533Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "ttl": "PT30S",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                }
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              }
+            ],
+            "payment": {
+              "type": "ON-ORDER"
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_track.json
+++ b/Lekhha/Retail-Logistics/Flow_A1_Delivery_Flow/Retail_track.json
@@ -1,0 +1,20 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "track",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "message_id": "a3d30a32-0708-44c5-a646-ac14b38820af",
+          "timestamp": "2025-04-24T17:54:25.862Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order_id": "SS1745516875776"
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Downloaded_logs_LBNP.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Downloaded_logs_LBNP.json
@@ -1,0 +1,4319 @@
+{
+    "domain": "nic2004:60232",
+    "payload": {
+      "search_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745516961\",expires=\"1745546961863\",headers=\"(created) (expires) digest\",signature=\"j1Ke+WCnUpB+O85VzxKtiwmqKJ2OVMAfQteN4CiTpqrYc/fZpJuzLUdDkYsZmgRIpTH2HCPl5LixUhl9wHhoBQ==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "search",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "6546e60f-bb01-4557-a8f4-84c272ee19fd",
+            "timestamp": "2025-04-24T17:49:21.863Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "intent": {
+              "category": {
+                "id": "Standard Delivery"
+              },
+              "provider": {
+                "time": {
+                  "days": "1,2,3,4,5,6,7",
+                  "schedule": {
+                    "holidays": []
+                  },
+                  "duration": "P0DT0H1M",
+                  "range": {
+                    "start": "0001",
+                    "end": "2359"
+                  }
+                }
+              },
+              "fulfillment": {
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "area_code": "560103"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              "payment": {
+                "type": "ON-ORDER"
+              },
+              "@ondc/org/payload_details": {
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                },
+                "category": "Grocery",
+                "value": {
+                  "currency": "INR",
+                  "value": "880"
+                },
+                "dangerous_goods": false
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "search",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "6546e60f-bb01-4557-a8f4-84c272ee19fd",
+            "timestamp": "2025-04-24T17:49:21.863Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_search_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745516963\",expires=\"1745520563\",headers=\"(created) (expires) digest\",signature=\"MvN4fxWGKZbgnMR6gJfDsK6iKXy+/Quj/MR3bWg/kh10GCQcvOs+T+K3f26pC0X7O8e1tKBpam9Wz7OJ/OuYDw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "6546e60f-bb01-4557-a8f4-84c272ee19fd",
+            "timestamp": "2025-04-24T17:49:23.159Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "catalog": {
+              "bpp/descriptor": {
+                "name": "ONDC Pramaaan Logistics"
+              },
+              "bpp/providers": [
+                {
+                  "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "descriptor": {
+                    "name": "ONDC Pramaaan Logistics",
+                    "short_desc": "Swiftly Yours, Delivered with Care",
+                    "long_desc": "We deliver everywhere—yes, even Mars (just give us a little more rocket fuel)."
+                  },
+                  "categories": [
+                    {
+                      "id": "Standard Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "Immediate Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      }
+                    },
+                    {
+                      "id": "Express Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "Next Day Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "Same Day Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  ],
+                  "fulfillments": [
+                    {
+                      "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT15M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT20M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "9e41392a-f17e-449b-9fd3-6661a494f707",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT30M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT30M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "0e71103f-54f5-4c36-99de-85b6d2166863",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT15M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                      "type": "RTO"
+                    }
+                  ],
+                  "items": [
+                    {
+                      "id": "rto_std",
+                      "parent_item_id": "std_del",
+                      "category_id": "Standard Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "rto_imd",
+                      "parent_item_id": "imd_del",
+                      "category_id": "Immediate Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Immediate Delivery",
+                        "long_desc": "Upto 60 mins for Delivery",
+                        "short_desc": "Upto 60 mins for Delivery"
+                      },
+                      "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "imd_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Immediate Delivery",
+                        "long_desc": "Upto 60 mins for Delivery",
+                        "short_desc": "Upto 60 mins for Delivery"
+                      },
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      }
+                    },
+                    {
+                      "id": "rto_exp",
+                      "parent_item_id": "exp_del",
+                      "category_id": "Express Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Express Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "exp_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Express Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Express Delivery",
+                      "fulfillment_id": "9e41392a-f17e-449b-9fd3-6661a494f707",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "rto_nex",
+                      "parent_item_id": "nex_del",
+                      "category_id": "Next Day Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Next Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "nex_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Next Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Next Day Delivery",
+                      "fulfillment_id": "aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "rto_same",
+                      "parent_item_id": "same_del",
+                      "category_id": "Same Day Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Same Day Delivery",
+                        "long_desc": "Same Delivery",
+                        "short_desc": "Same for Delivery"
+                      },
+                      "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "same_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Same Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Same Day Delivery",
+                      "fulfillment_id": "0e71103f-54f5-4c36-99de-85b6d2166863",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "6546e60f-bb01-4557-a8f4-84c272ee19fd",
+            "timestamp": "2025-04-24T17:49:23.159Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK",
+              "tags": [
+                {
+                  "display": true,
+                  "code": "string",
+                  "name": "string",
+                  "list": [
+                    {
+                      "code": "string",
+                      "name": "string",
+                      "value": "string",
+                      "display": true
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "error": {
+            "type": "CONTEXT-ERROR",
+            "code": "string",
+            "path": "string",
+            "message": "string"
+          }
+        }
+      },
+      "init_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517001\",expires=\"1745547001274\",headers=\"(created) (expires) digest\",signature=\"igaQ4nHvl4qUvFbqzqfoQTjFKgEWBdRlKhVgVXEbKnuXZfnIuuacLyuTFPqkGMe0XAmpufGOGg2kPGEqZTkKDw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "ba9efae5-a00a-4c59-ac9c-347b00f12f62",
+            "timestamp": "2025-04-24T17:50:01.274Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "category_id": "Standard Delivery",
+                  "descriptor": {
+                    "code": "P2P"
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "ba9efae5-a00a-4c59-ac9c-347b00f12f62",
+            "timestamp": "2025-04-24T17:50:01.274Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_init_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517001\",expires=\"1745520601\",headers=\"(created) (expires) digest\",signature=\"/EkZRGx3089rp2Niq7MqclttrQ+2BAhZuTR+CPc62MyQBC10D42635w10s1SeAQGREwxV67wMHz8CEZqshTXCA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "ba9efae5-a00a-4c59-ac9c-347b00f12f62",
+            "timestamp": "2025-04-24T17:50:01.316Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  }
+                }
+              ],
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ],
+                "ttl": "P7D"
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "ba9efae5-a00a-4c59-ac9c-347b00f12f62",
+            "timestamp": "2025-04-24T17:50:01.316Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK",
+              "tags": [
+                {
+                  "display": true,
+                  "code": "string",
+                  "name": "string",
+                  "list": [
+                    {
+                      "code": "string",
+                      "name": "string",
+                      "value": "string",
+                      "display": true
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "confirm_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517218\",expires=\"1745547218090\",headers=\"(created) (expires) digest\",signature=\"cQBFBGrCLQjN6Ktk8SCjplxO3KXZxGEEYwmBhtFggkZ/ju7W0nUM89Vt49hDJJVWHEfQduegvZT9poz3+7AsDA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "confirm",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "2c30dcc9-aace-442f-926e-d046fd12ee95",
+            "timestamp": "2025-04-24T17:53:38.090Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "category_id": "Standard Delivery",
+                  "descriptor": {
+                    "code": "P2P"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "id": "SS1745517217464",
+              "state": "Created",
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517217464",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "tags": [
+                {
+                  "code": "bap_terms",
+                  "list": [
+                    {
+                      "code": "accept_bpp_terms",
+                      "value": "Y"
+                    }
+                  ]
+                }
+              ],
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:53:38.051Z"
+            }
+          }
+        },
+        "response": {
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_confirm_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517218\",expires=\"1745520818\",headers=\"(created) (expires) digest\",signature=\"qU3P0zGaw5w+B7QDf2GU38PFZGzi1RMUdzxw1JMnTFw5kKPVXDqj2rQkjCmuLBrWjAFoh99zfP7UP9jMt9IdAw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "2c30dcc9-aace-442f-926e-d046fd12ee95",
+            "timestamp": "2025-04-24T17:53:38.138Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "Accepted",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Pending"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517217464",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:53:38.138Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "2c30dcc9-aace-442f-926e-d046fd12ee95",
+            "timestamp": "2025-04-24T17:53:38.138Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "update_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517332\",expires=\"1745547332796\",headers=\"(created) (expires) digest\",signature=\"vkKit4+zTiv5ZfDDpXUs2TeBQvl0BzAZn2SmyZ7iNi0kgjFa0jFZ1pNROJI+2TVSORd/R5+7gKWsA/KNSqu1Bw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "update",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "ff539e77-e633-4b18-a8f3-2a8768f770ea",
+            "timestamp": "2025-04-24T17:55:32.796Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "update_target": "fulfillment",
+            "order": {
+              "id": "SS1745517217464",
+              "state": "Created",
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "descriptor": {
+                    "code": "P2P"
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship",
+                          "value": "yes"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "updated_at": "2025-04-24T23:25:32.785Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "update",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "ff539e77-e633-4b18-a8f3-2a8768f770ea",
+            "timestamp": "2025-04-24T17:55:32.796Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_update_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517334\",expires=\"1745520934\",headers=\"(created) (expires) digest\",signature=\"AMRWpUm4ttsArRscoPEerXINNq8H6DyvyO4z/ozR3hrDfj7JYu/OdCLofK+siEYRGlLntN6QOBLEbyFkJZw3CA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_update",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "ff539e77-e633-4b18-a8f3-2a8768f770ea",
+            "timestamp": "2025-04-24T17:55:34.255Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "Accepted",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Searching-for-Agent"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517217464",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:53:38.138Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_update",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "ff539e77-e633-4b18-a8f3-2a8768f770ea",
+            "timestamp": "2025-04-24T17:55:34.255Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517342\",expires=\"1745520942\",headers=\"(created) (expires) digest\",signature=\"4BSZ9Ha8QBHpMw82qDxxwEszNXO+LU9YHAuRG2qHVqcayab1OR/0OJCDgb1cwn9gj3TIxHzPysfyq6D4PH2TDg==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "9793b10a-3048-44ed-a2cd-17651bb6a425",
+            "timestamp": "2025-04-24T17:55:42.774Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "In-progress",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Agent-assigned"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517217464",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:55:42.774Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "9793b10a-3048-44ed-a2cd-17651bb6a425",
+            "timestamp": "2025-04-24T17:55:42.774Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_2": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517357\",expires=\"1745520957\",headers=\"(created) (expires) digest\",signature=\"vJhTGRtFgoavqa/BHw6j3G06LGNA5+PXh2FQtpdaZbwDohIQkwBKM6/zf1a99+UgshQnO1BvQwqjsWkhogQAAA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "fe4079a9-acfa-40c8-b382-d86c6d5e898b",
+            "timestamp": "2025-04-24T17:55:57.504Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "In-progress",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-picked-up"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:55:57.504Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "status": "NOT-PAID"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517217464",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:55:57.504Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "fe4079a9-acfa-40c8-b382-d86c6d5e898b",
+            "timestamp": "2025-04-24T17:55:57.504Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_3": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517363\",expires=\"1745520963\",headers=\"(created) (expires) digest\",signature=\"XqL2WJccgLoAloKJk/BGWedwS5Tvb01UrrfVoan5EyGk5QsFM+LXdfh0tt4WcPXYbQiA05mt5nfqdmtRvUSgCw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "aa0004c8-e507-47c3-adf5-201341d9ec7f",
+            "timestamp": "2025-04-24T17:56:03.540Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "In-progress",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Out-for-delivery"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:55:57.504Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "status": "NOT-PAID"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517217464",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:56:03.540Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "aa0004c8-e507-47c3-adf5-201341d9ec7f",
+            "timestamp": "2025-04-24T17:56:03.540Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "status_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517377\",expires=\"1745547377609\",headers=\"(created) (expires) digest\",signature=\"/F8lXWeeckmemCPi1JQ6lxkQmi03IurlV20YibpAF8VIvw9aOVUK0oJThSe5atEF7YvChJEjkER+dvL8+f86Cw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "926cf1b1-e36a-466f-be98-e6af2ac74f04",
+            "timestamp": "2025-04-24T17:56:17.609Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order_id": "SS1745517217464"
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "926cf1b1-e36a-466f-be98-e6af2ac74f04",
+            "timestamp": "2025-04-24T17:56:17.609Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_4": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517379\",expires=\"1745520979\",headers=\"(created) (expires) digest\",signature=\"1Wzrd34Q1480x9lo5DFInPZyf1E9ARS6hoc7gYJwLKAtsxe2h0r88ExCCXxuT+tzH1l4LJG/WI4uMCerOjsCAQ==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "926cf1b1-e36a-466f-be98-e6af2ac74f04",
+            "timestamp": "2025-04-24T17:56:19.084Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "In-progress",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Out-for-delivery"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:55:57.504Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "status": "NOT-PAID"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517217464",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:56:03.540Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "926cf1b1-e36a-466f-be98-e6af2ac74f04",
+            "timestamp": "2025-04-24T17:56:19.084Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_cancel_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517390\",expires=\"1745520990\",headers=\"(created) (expires) digest\",signature=\"iHDHkFlgC638U92iaQqv6ffetep9kt4UJFMnAcGEiGJ/NrN65S7B9uIjsWkM+25SRG2akjzfdCM5k7QnYMdmCw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_cancel",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "f5d994d5-c4d0-4c09-8160-2a3877968e28",
+            "timestamp": "2025-04-24T17:56:28.834Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT100S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "Cancelled",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "rto_std",
+                  "parent_item_id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "2612.06"
+                  }
+                },
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Cancelled"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:55:57.504Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "precancel_state",
+                      "list": [
+                        {
+                          "code": "fulfillment_state",
+                          "value": "Out-for-delivery"
+                        },
+                        {
+                          "code": "updated_at",
+                          "value": "2025-04-24T17:56:03.540Z"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_event",
+                      "list": [
+                        {
+                          "code": "rto_id",
+                          "value": "968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                        },
+                        {
+                          "code": "cancellation_reason_id",
+                          "value": "016"
+                        },
+                        {
+                          "code": "cancelled_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                        },
+                        {
+                          "code": "retry_count",
+                          "value": "2"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                },
+                {
+                  "id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                  "type": "RTO",
+                  "state": {
+                    "descriptor": {
+                      "code": "RTO-Initiated"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T17:56:28.834Z",
+                        "end": "2025-04-24T17:56:28.834Z"
+                      },
+                      "timestamp": "2025-04-24T17:56:28.834Z"
+                    },
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "7816"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  },
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    },
+                    "@ondc/org/item_id": "rto_std",
+                    "@ondc/org/title_type": "rto"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "rto_std",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "status": "NOT-PAID"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517217464",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:56:28.834Z",
+              "cancellation": {
+                "cancelled_by": "pramaan.ondc.org/beta/preprod/mock/seller",
+                "reason": {
+                  "id": "016"
+                }
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_cancel",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "f5d994d5-c4d0-4c09-8160-2a3877968e28",
+            "timestamp": "2025-04-24T17:56:28.834Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT100S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_5": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517431\",expires=\"1745521031\",headers=\"(created) (expires) digest\",signature=\"L+qO/QF1VHa2gB8ybKmCnUOSwKg5F1xmd7MoykUarR81ZT8CbOZ+CVEooiU1n8a+UyITvpgy88dmLY4Y1rrWCA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "2776e315-023e-46a7-b89a-d6cdd8b92889",
+            "timestamp": "2025-04-24T17:57:11.747Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT100S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "Cancelled",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "rto_std",
+                  "parent_item_id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "2612.06"
+                  }
+                },
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Cancelled"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:55:57.504Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "precancel_state",
+                      "list": [
+                        {
+                          "code": "fulfillment_state",
+                          "value": "Out-for-delivery"
+                        },
+                        {
+                          "code": "updated_at",
+                          "value": "2025-04-24T17:56:03.540Z"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_event",
+                      "list": [
+                        {
+                          "code": "rto_id",
+                          "value": "968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                        },
+                        {
+                          "code": "cancellation_reason_id",
+                          "value": "016"
+                        },
+                        {
+                          "code": "cancelled_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                        },
+                        {
+                          "code": "retry_count",
+                          "value": "2"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                },
+                {
+                  "id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                  "type": "RTO",
+                  "state": {
+                    "descriptor": {
+                      "code": "RTO-Delivered"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T17:56:28.834Z",
+                        "end": "2025-04-24T17:56:28.834Z"
+                      },
+                      "timestamp": "2025-04-24T17:56:28.834Z"
+                    },
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "timestamp": "2025-04-24T17:57:11.747Z"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "7816"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  },
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    },
+                    "@ondc/org/item_id": "rto_std",
+                    "@ondc/org/title_type": "rto"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "rto_std",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "status": "NOT-PAID"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517217464",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:56:28.834Z",
+              "cancellation": {
+                "cancelled_by": "pramaan.ondc.org/beta/preprod/mock/seller",
+                "reason": {
+                  "id": "016"
+                }
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "2776e315-023e-46a7-b89a-d6cdd8b92889",
+            "timestamp": "2025-04-24T17:57:11.747Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT100S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "status_2": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517486\",expires=\"1745547486042\",headers=\"(created) (expires) digest\",signature=\"+u2yoC3VvABk+ykurB9fGZooh9qX2F6++n6hPB+b1sSvV+crtPyJbW2qrROQTE8+P44iO5+C/t3kAv9XntUFCw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "41c45b11-2c48-41e5-af04-6bbd16bea54b",
+            "timestamp": "2025-04-24T17:58:06.042Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order_id": "SS1745517217464"
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "41c45b11-2c48-41e5-af04-6bbd16bea54b",
+            "timestamp": "2025-04-24T17:58:06.042Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_6": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517487\",expires=\"1745521087\",headers=\"(created) (expires) digest\",signature=\"o4Z4HZMabXs7wlHuPJqy8lxilWJf8fl5CqBDi51ltvq54W+P5AAWvBkzT0BYPF2GDkMa1pJk12pUutvQ0G7rAg==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "41c45b11-2c48-41e5-af04-6bbd16bea54b",
+            "timestamp": "2025-04-24T17:58:07.849Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "Cancelled",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "rto_std",
+                  "parent_item_id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "2612.06"
+                  }
+                },
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Cancelled"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:55:57.504Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "precancel_state",
+                      "list": [
+                        {
+                          "code": "fulfillment_state",
+                          "value": "Out-for-delivery"
+                        },
+                        {
+                          "code": "updated_at",
+                          "value": "2025-04-24T17:56:03.540Z"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_event",
+                      "list": [
+                        {
+                          "code": "rto_id",
+                          "value": "968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                        },
+                        {
+                          "code": "cancellation_reason_id",
+                          "value": "016"
+                        },
+                        {
+                          "code": "cancelled_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                        },
+                        {
+                          "code": "retry_count",
+                          "value": "2"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                },
+                {
+                  "id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                  "type": "RTO",
+                  "state": {
+                    "descriptor": {
+                      "code": "RTO-Delivered"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T17:56:28.834Z",
+                        "end": "2025-04-24T17:56:28.834Z"
+                      },
+                      "timestamp": "2025-04-24T17:56:28.834Z"
+                    },
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "timestamp": "2025-04-24T17:57:11.747Z"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "7816"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  },
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    },
+                    "@ondc/org/item_id": "rto_std",
+                    "@ondc/org/title_type": "rto"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "rto_std",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "status": "NOT-PAID"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517217464",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:56:28.834Z",
+              "cancellation": {
+                "cancelled_by": "pramaan.ondc.org/beta/preprod/mock/seller",
+                "reason": {
+                  "id": "016"
+                }
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "41c45b11-2c48-41e5-af04-6bbd16bea54b",
+            "timestamp": "2025-04-24T17:58:07.849Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      }
+    }
+  }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Downloaded_logs_Retail.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Downloaded_logs_Retail.json
@@ -1,0 +1,8083 @@
+{
+    "domain": "ONDC:RET10",
+    "payload": {
+      "search_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745516933\",expires=\"1745520533\",headers=\"(created) (expires) digest\",signature=\"9Mb5yvTLYWQU4t84ELsoheeLI9gdRANMe863Ns8UwpyQ2oVaCxAS0/95zpLrfgtpKKy7hw9mQfwYB/6mrxeRBg==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "search",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "98e7e7ab-95f9-43fb-b8b8-7b5dc990820e",
+            "timestamp": "2025-04-24T17:48:53.899Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "intent": {
+              "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3"
+              },
+              "tags": [
+                {
+                  "code": "catalog_full",
+                  "list": [
+                    {
+                      "code": "payload_type",
+                      "value": "inline"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "action": "search",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "98e7e7ab-95f9-43fb-b8b8-7b5dc990820e",
+            "timestamp": "2025-04-24T17:48:54.007Z",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_search_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745516938\",expires=\"1745546938102\",headers=\"(created) (expires) digest\",signature=\"sYJcJq0fs63c4KH2Z355wIy7T8GE3j35wY1Op/1CMPawYQJ5YNERRO8oakzMnvWeOlkfO+I2+iS+ua39EuCMAw==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "98e7e7ab-95f9-43fb-b8b8-7b5dc990820e",
+            "timestamp": "2025-04-24T17:48:58.096Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "catalog": {
+              "bpp/fulfillments": [
+                {
+                  "id": "1",
+                  "type": "Delivery",
+                  "contact": {
+                    "phone": "9900025784",
+                    "email": "sgupta.scm@gmail.com"
+                  }
+                }
+              ],
+              "bpp/descriptor": {
+                "name": "Lekhha",
+                "symbol": "https://lekhha.com/wp-content/uploads/2023/07/logo-light-1.png",
+                "short_desc": "App-based platform for order and inventory management.",
+                "long_desc": "LEKHHA is a simple solution to help you comprehensively run your business operations. Discover it to also track & manage your personal needs & resources. Reach out to us to serve you as your solution partner.",
+                "images": [
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/logo",
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/vendor",
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/consumer",
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/inventory"
+                ],
+                "tags": [
+                  {
+                    "code": "bpp_terms",
+                    "list": [
+                      {
+                        "code": "np_type",
+                        "value": "MSN"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "bpp/providers": [
+                {
+                  "id": "674ecb33d7b9e10f4210d972",
+                  "time": {
+                    "label": "enable",
+                    "timestamp": "2025-04-24T17:48:57.338Z"
+                  },
+                  "descriptor": {
+                    "name": "Lekhha Provider A",
+                    "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecb33d7b9e10f4210d972_S",
+                    "short_desc": "Lekhha_Seller_1 kyc short",
+                    "long_desc": "Lekhha_Seller_1 kyc long",
+                    "images": [
+                      "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecb33d7b9e10f4210d972"
+                    ]
+                  },
+                  "ttl": "P1D",
+                  "creds": [
+                    {
+                      "descriptor": {
+                        "code": "Lekhha_Seller_1_cred1",
+                        "name": "Lekhha_Seller_1 cred1",
+                        "short_desc": "Lekhha_Seller_1 cred1 short"
+                      },
+                      "id": "674ecbc6d7b9e10f4210d973_1",
+                      "tags": [
+                        {
+                          "code": "verification",
+                          "list": [
+                            {
+                              "code": "verify_url",
+                              "value": "https://url1url.com/verify1"
+                            },
+                            {
+                              "code": "valid_from",
+                              "value": "2024-12-09T00:00:00.000Z"
+                            },
+                            {
+                              "code": "valid_to",
+                              "value": "2027-03-31T00:00:00.000Z"
+                            }
+                          ]
+                        }
+                      ],
+                      "url": "https://url1url.com"
+                    }
+                  ],
+                  "fulfillments": [
+                    {
+                      "id": "1",
+                      "type": "Delivery",
+                      "contact": {
+                        "phone": "9900025784",
+                        "email": "sgupta.scm@gmail.com"
+                      }
+                    }
+                  ],
+                  "tags": [
+                    {
+                      "code": "order_value",
+                      "list": [
+                        {
+                          "code": "min_value",
+                          "value": "150.5"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "timing",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "Order"
+                        },
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "day_from",
+                          "value": "1"
+                        },
+                        {
+                          "code": "day_to",
+                          "value": "7"
+                        },
+                        {
+                          "code": "time_from",
+                          "value": "0001"
+                        },
+                        {
+                          "code": "time_to",
+                          "value": "2359"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "timing",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "Delivery"
+                        },
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "day_from",
+                          "value": "1"
+                        },
+                        {
+                          "code": "day_to",
+                          "value": "7"
+                        },
+                        {
+                          "code": "time_from",
+                          "value": "0001"
+                        },
+                        {
+                          "code": "time_to",
+                          "value": "2359"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "timing",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "Self-Pickup"
+                        },
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "day_from",
+                          "value": "1"
+                        },
+                        {
+                          "code": "day_to",
+                          "value": "7"
+                        },
+                        {
+                          "code": "time_from",
+                          "value": "0001"
+                        },
+                        {
+                          "code": "time_to",
+                          "value": "2359"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "serviceability",
+                      "list": [
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "category",
+                          "value": "Bakery, Cakes & Dairy"
+                        },
+                        {
+                          "code": "type",
+                          "value": "11"
+                        },
+                        {
+                          "code": "val",
+                          "value": "100000-999999"
+                        },
+                        {
+                          "code": "unit",
+                          "value": "pincode"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "serviceability",
+                      "list": [
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "category",
+                          "value": "Energy and Soft Drinks"
+                        },
+                        {
+                          "code": "type",
+                          "value": "11"
+                        },
+                        {
+                          "code": "val",
+                          "value": "100000-999999"
+                        },
+                        {
+                          "code": "unit",
+                          "value": "pincode"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "serviceability",
+                      "list": [
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "category",
+                          "value": "Fruits and Vegetables"
+                        },
+                        {
+                          "code": "type",
+                          "value": "11"
+                        },
+                        {
+                          "code": "val",
+                          "value": "100000-999999"
+                        },
+                        {
+                          "code": "unit",
+                          "value": "pincode"
+                        }
+                      ]
+                    }
+                  ],
+                  "items": [
+                    {
+                      "id": "676a61f6cac4860876a8e30f",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:48:57.596Z"
+                      },
+                      "parent_item_id": "V10000000001",
+                      "descriptor": {
+                        "name": "Milk orange",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk orange short",
+                        "long_desc": "Milk orange long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e3_0"
+                        ],
+                        "code": "1:1000000000232"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "13"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "49.82",
+                        "maximum_value": "53.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 11",
+                        "additives_info": "additives info 11",
+                        "brand_owner_FSSAI_license_no": "fssai license 11",
+                        "other_FSSAI_license_no": "other license 11",
+                        "importer_FSSAI_license_no": "importer license 11"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 11",
+                        "manufacturer_or_packer_address": "address 11",
+                        "common_or_generic_name_of_commodity": "commodity 11",
+                        "month_year_of_manufacture_packing_import": "year 11"
+                      }
+                    },
+                    {
+                      "id": "676a6179cac4860876a8e30b",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:48:57.631Z"
+                      },
+                      "parent_item_id": "V10000000002",
+                      "descriptor": {
+                        "name": "Milk blue",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk blue short",
+                        "long_desc": "Milk blue long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e5_0"
+                        ],
+                        "code": "1:1000000000233"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "10"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "12"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "380.00",
+                        "maximum_value": "400.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 9",
+                        "additives_info": "additives info 9",
+                        "brand_owner_FSSAI_license_no": "fssai license 9",
+                        "other_FSSAI_license_no": "other license 9",
+                        "importer_FSSAI_license_no": "importer license 9"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 9",
+                        "manufacturer_or_packer_address": "address 9",
+                        "common_or_generic_name_of_commodity": "commodity 9",
+                        "month_year_of_manufacture_packing_import": "year 9"
+                      }
+                    },
+                    {
+                      "id": "676a6260cac4860876a8e311",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:48:57.664Z"
+                      },
+                      "parent_item_id": "V10000000001",
+                      "descriptor": {
+                        "name": "Milk orange",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk orange short",
+                        "long_desc": "Milk orange long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e7_0"
+                        ],
+                        "code": "1:1000000000234"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "10"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "14"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "500.00",
+                        "maximum_value": "500.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 12",
+                        "additives_info": "additives info 12",
+                        "brand_owner_FSSAI_license_no": "fssai license 12",
+                        "other_FSSAI_license_no": "other license 12",
+                        "importer_FSSAI_license_no": "importer license 12"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 12",
+                        "manufacturer_or_packer_address": "address 12",
+                        "common_or_generic_name_of_commodity": "commodity 12",
+                        "month_year_of_manufacture_packing_import": "year 12"
+                      }
+                    },
+                    {
+                      "id": "676cf465e5eb3c28a8741e99",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:48:57.747Z"
+                      },
+                      "descriptor": {
+                        "name": "Pista milk",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Pista milk short",
+                        "long_desc": "Pista milk long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd72c_0"
+                        ],
+                        "code": "1:1000000000240"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "32"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "18.50",
+                        "maximum_value": "20.00"
+                      },
+                      "category_id": "Energy and Soft Drinks",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 18",
+                        "additives_info": "additives info 18",
+                        "brand_owner_FSSAI_license_no": "fssai license 18",
+                        "other_FSSAI_license_no": "other license 18",
+                        "importer_FSSAI_license_no": "importer license 18"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 18",
+                        "manufacturer_or_packer_address": "address 18",
+                        "common_or_generic_name_of_commodity": "commodity 18",
+                        "month_year_of_manufacture_packing_import": "year 18"
+                      }
+                    },
+                    {
+                      "id": "676cf465e5eb3c28a8741e9a",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:48:57.763Z"
+                      },
+                      "descriptor": {
+                        "name": "Mango milk",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Mango milk short",
+                        "long_desc": "Mango milk long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd72e_0"
+                        ],
+                        "code": "1:1000000000241"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "33"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "20.16",
+                        "maximum_value": "21.80"
+                      },
+                      "category_id": "Energy and Soft Drinks",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 7",
+                        "additives_info": "additives info 7",
+                        "brand_owner_FSSAI_license_no": "fssai license 7",
+                        "other_FSSAI_license_no": "other license 7",
+                        "importer_FSSAI_license_no": "importer license 7"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 7",
+                        "manufacturer_or_packer_address": "address 7",
+                        "common_or_generic_name_of_commodity": "commodity 7",
+                        "month_year_of_manufacture_packing_import": "year 7"
+                      }
+                    },
+                    {
+                      "id": "676cf465e5eb3c28a8741e9b",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:48:57.780Z"
+                      },
+                      "descriptor": {
+                        "name": "Vanilla milk",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Vanilla milk short",
+                        "long_desc": "Vanilla milk long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd730_0"
+                        ],
+                        "code": "1:1000000000242"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "35"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "18.51",
+                        "maximum_value": "20.01"
+                      },
+                      "category_id": "Energy and Soft Drinks",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 19",
+                        "additives_info": "additives info 19",
+                        "brand_owner_FSSAI_license_no": "fssai license 19",
+                        "other_FSSAI_license_no": "other license 19",
+                        "importer_FSSAI_license_no": "importer license 19"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer name 19",
+                        "manufacturer_or_packer_address": "packer address 19",
+                        "common_or_generic_name_of_commodity": "generic name 19",
+                        "month_year_of_manufacture_packing_import": "month year 19"
+                      }
+                    },
+                    {
+                      "id": "676a5f87cac4860876a8e2ff",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:48:57.793Z"
+                      },
+                      "descriptor": {
+                        "name": "Butter",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Butter short",
+                        "long_desc": "Butter long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd736_0"
+                        ],
+                        "code": "1:1000000000245"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "gram",
+                            "value": "200"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "23"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "109.38",
+                        "maximum_value": "124.30"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 3",
+                        "additives_info": "additives info 3",
+                        "brand_owner_FSSAI_license_no": "fssai license 3",
+                        "other_FSSAI_license_no": "other license 3",
+                        "importer_FSSAI_license_no": "importer license 3"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 13",
+                        "manufacturer_or_packer_address": "address 13",
+                        "common_or_generic_name_of_commodity": "commodity 13",
+                        "month_year_of_manufacture_packing_import": "year 13"
+                      }
+                    },
+                    {
+                      "id": "676a5f11cac4860876a8e2fb",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:48:57.810Z"
+                      },
+                      "descriptor": {
+                        "name": "Burfi",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Burfi short",
+                        "long_desc": "Burfi long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd73a_0"
+                        ],
+                        "code": "1:1000000000247"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "gram",
+                            "value": "200"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "22"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "71.20",
+                        "maximum_value": "80.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 2",
+                        "additives_info": "additives info 2",
+                        "brand_owner_FSSAI_license_no": "fssai license 2",
+                        "other_FSSAI_license_no": "other license 2",
+                        "importer_FSSAI_license_no": "importer license 2"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer name 2",
+                        "manufacturer_or_packer_address": "packer address 2",
+                        "common_or_generic_name_of_commodity": "commodity 2",
+                        "month_year_of_manufacture_packing_import": "packing import 2"
+                      }
+                    },
+                    {
+                      "id": "676aab3800d7d9212e3ba074",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:48:57.825Z"
+                      },
+                      "descriptor": {
+                        "name": "Watermelon",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Watermelon short",
+                        "long_desc": "Watermelon long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd740_0"
+                        ],
+                        "code": "1:2000000000349"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "46"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "45.00",
+                        "maximum_value": "45.00"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a9e1d00d7d9212e3b8f7f",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:48:57.837Z"
+                      },
+                      "descriptor": {
+                        "name": "Apple",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Apple short",
+                        "long_desc": "Apple long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd742_0"
+                        ],
+                        "code": "1:2000000000341"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "21"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "120.02",
+                        "maximum_value": "120.02"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676aaa5700d7d9212e3ba019",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:48:57.849Z"
+                      },
+                      "descriptor": {
+                        "name": "Papaya",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Papaya short",
+                        "long_desc": "Papaya long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd746_0"
+                        ],
+                        "code": "1:2000000000346"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "29"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "61.28",
+                        "maximum_value": "64.50"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a9fa200d7d9212e3b8fbd",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:48:57.863Z"
+                      },
+                      "descriptor": {
+                        "name": "Beetroot",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Beetroot short",
+                        "long_desc": "Beetroot long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6762dbb841c7aa7c86d1d1c2_0"
+                        ],
+                        "code": "1:2000000000343"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "0"
+                        },
+                        "maximum": {
+                          "count": "6"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "30.00",
+                        "maximum_value": "30.00"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a9f7800d7d9212e3b8fbb",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:48:57.876Z"
+                      },
+                      "descriptor": {
+                        "name": "Beans haricot",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Beans haricot short",
+                        "long_desc": "Beans haricot long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6762dbb841c7aa7c86d1d1c4_0"
+                        ],
+                        "code": "1:2000000000342"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "0"
+                        },
+                        "maximum": {
+                          "count": "5"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "76.42",
+                        "maximum_value": "78.38"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a6126cac4860876a8e309",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:48:57.962Z"
+                      },
+                      "parent_item_id": "V10000000002",
+                      "descriptor": {
+                        "name": "Milk blue",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk blue short",
+                        "long_desc": "Milk blue long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e1_0"
+                        ],
+                        "code": "1:1000000000231"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "11"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00",
+                        "maximum_value": "40.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 8",
+                        "additives_info": "additives info 8",
+                        "brand_owner_FSSAI_license_no": "fssai license 8",
+                        "other_FSSAI_license_no": "other license 8",
+                        "importer_FSSAI_license_no": "importer license 8"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 8",
+                        "manufacturer_or_packer_address": "address 8",
+                        "common_or_generic_name_of_commodity": "commodity 8",
+                        "month_year_of_manufacture_packing_import": "year 8"
+                      }
+                    }
+                  ],
+                  "locations": [
+                    {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:48:57.359Z",
+                        "days": "1,2,3,4,5,6,7",
+                        "schedule": {
+                          "holidays": []
+                        },
+                        "range": {
+                          "start": "0001",
+                          "end": "2359"
+                        }
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "locality": "Bengaluru",
+                        "street": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "city": "Bengaluru",
+                        "area_code": "560103",
+                        "state": "KA"
+                      },
+                      "circle": {
+                        "gps": "12.9263841,77.6654374",
+                        "radius": {
+                          "unit": "km",
+                          "value": "999"
+                        }
+                      }
+                    }
+                  ],
+                  "categories": [
+                    {
+                      "id": "V10000000001",
+                      "descriptor": {
+                        "name": "Variant Group 10000000001"
+                      },
+                      "tags": [
+                        {
+                          "code": "type",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "variant_group"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "attr",
+                          "list": [
+                            {
+                              "code": "name",
+                              "value": "item.quantity.unitized.measure"
+                            },
+                            {
+                              "code": "seq",
+                              "value": "1"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "V10000000002",
+                      "descriptor": {
+                        "name": "Variant Group 10000000002"
+                      },
+                      "tags": [
+                        {
+                          "code": "type",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "variant_group"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "attr",
+                          "list": [
+                            {
+                              "code": "name",
+                              "value": "item.quantity.unitized.measure"
+                            },
+                            {
+                              "code": "seq",
+                              "value": "1"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "98e7e7ab-95f9-43fb-b8b8-7b5dc990820e",
+            "timestamp": "2025-04-24T17:48:58.096Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            },
+            "tags": [
+              {
+                "code": "CATALOG_PROCESSING",
+                "list": [
+                  {
+                    "code": "MIN_PROCESS_DURATION",
+                    "value": "PT1S"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "select_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745516961\",expires=\"1745520561\",headers=\"(created) (expires) digest\",signature=\"LsE+owVq/YFMCSGIZdXJUlROhV2oZyzvnQ7UBZ5sbu+xgI2YgHTIMwA66nbLjp69iYY/g56dThBFZCuEW648Dg==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "select",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "3e91f782-7627-4849-8b5e-a745943b2fec",
+            "timestamp": "2025-04-24T17:49:21.241Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  }
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                }
+              ],
+              "payment": {
+                "type": "ON-ORDER"
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "select",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "3e91f782-7627-4849-8b5e-a745943b2fec",
+            "timestamp": "2025-04-24T17:49:21.721Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_select_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745516969\",expires=\"1745546969646\",headers=\"(created) (expires) digest\",signature=\"CPzzv0P/ePtr1+NyaooVatedEhEYBaq1c0Ej+OkZJroXtoNHzFl0vuzE+f4MOOZupBTWmhu8K20CDg3GlygpBA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_select",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "3e91f782-7627-4849-8b5e-a745943b2fec",
+            "timestamp": "2025-04-24T17:49:29.643Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "id": "676a6179cac4860876a8e30b",
+                  "quantity": {
+                    "count": 2
+                  }
+                },
+                {
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "id": "676a6126cac4860876a8e309",
+                  "quantity": {
+                    "count": 3
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "680a79a248665475e6bf8c64~I1~1~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Ecom Express Limited",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P5D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a79a248665475e6bf8c67~P1~I1~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Bharat Mart",
+                  "tracking": false,
+                  "@ondc/org/category": "Immediate Delivery",
+                  "@ondc/org/TAT": "PT60M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a79a348665475e6bf8c69~MOVERDELIVERY~I1~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Mover",
+                  "tracking": false,
+                  "@ondc/org/category": "Immediate Delivery",
+                  "@ondc/org/TAT": "PT30M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a79a348665475e6bf8c6b~Delhivery~55993af7-96f7-4dce-ac13-4c9132acf5af~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Delhivery",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P4D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a79a348665475e6bf8c6c~P1~I1~I1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Exeed Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P8D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Immediate Delivery",
+                  "@ondc/org/TAT": "PT60M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~9e41392a-f17e-449b-9fd3-6661a494f707",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Express Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Next Day Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~0e71103f-54f5-4c36-99de-85b6d2166863",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Same Day Delivery",
+                  "@ondc/org/TAT": "PT4H",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "NS_LSP",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "PT55M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "NS_LSP",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "PT55M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a79a348665475e6bf8c70~19537~YAARI-19537-20250424-AI6VUITR7J~SY-1745516963204-764",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Ecom Express",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a79a448665475e6bf8c71~DTDC~B2C SMART EXPRESS~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "DTDC",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P4D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "128335.18"
+                },
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "quantity": {
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "12"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "quantity": {
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "11"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a248665475e6bf8c64~I1~1~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "69"
+                    },
+                    "lsp_provider_id": "I1",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "1",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "name": "Standard Delivery",
+                        "code": "P2H2P",
+                        "short_desc": "Fast Delivery For Items",
+                        "long_desc": "Fast Delivery for Items"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "1",
+                      "price": {
+                        "currency": "INR",
+                        "value": "69"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "timestamp": "2025-04-28",
+                        "duration": "P5D"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a248665475e6bf8c67~P1~I1~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "59.00"
+                    },
+                    "lsp_provider_id": "P1",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "I1",
+                      "parent_item_id": "",
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "1",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "60 min delivery",
+                        "short_desc": "60 min delivery for F&B",
+                        "long_desc": "60 min delivery for F&B"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "59.00"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2023-06-06"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c69~MOVERDELIVERY~I1~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "25527"
+                    },
+                    "lsp_provider_id": "MOVERDELIVERY",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "I1",
+                      "parent_item_id": "",
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "1",
+                      "descriptor": {
+                        "name": "30 min delivery",
+                        "short_desc": "30 min delivery for F&B",
+                        "long_desc": "30 min delivery for F&B",
+                        "code": "P2P"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "25527"
+                      },
+                      "time": {
+                        "duration": "PT30M",
+                        "label": "TAT",
+                        "timestamp": "2025-04-24T17:49:22.7616047Z"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6b~Delhivery~55993af7-96f7-4dce-ac13-4c9132acf5af~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "7500.72"
+                    },
+                    "lsp_provider_id": "Delhivery",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "55993af7-96f7-4dce-ac13-4c9132acf5af",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "1",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Standard Delivery",
+                        "short_desc": "Delhivery Surface",
+                        "long_desc": "Delhivery Surface"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "7500.72"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P4D",
+                        "timestamp": "2025-04-28"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6c~P1~I1~I1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "65560.00"
+                    },
+                    "lsp_provider_id": "P1",
+                    "lsp_fulfillment_id": "I1",
+                    "lsp_item_details": {
+                      "id": "I1",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "I1",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Standard",
+                        "short_desc": "Standard",
+                        "long_desc": "Standard"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "65560.00"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P8D",
+                        "timestamp": "2025-04-24T17:49:23.026281Z"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                    "lsp_item_details": {
+                      "id": "imd_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Immediate Delivery",
+                        "long_desc": "Upto 60 mins for Delivery",
+                        "short_desc": "Upto 60 mins for Delivery"
+                      },
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~9e41392a-f17e-449b-9fd3-6661a494f707",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "9e41392a-f17e-449b-9fd3-6661a494f707",
+                    "lsp_item_details": {
+                      "id": "exp_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Express Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Express Delivery",
+                      "fulfillment_id": "9e41392a-f17e-449b-9fd3-6661a494f707",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                    "lsp_item_details": {
+                      "id": "nex_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Next Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Next Day Delivery",
+                      "fulfillment_id": "aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~0e71103f-54f5-4c36-99de-85b6d2166863",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "0e71103f-54f5-4c36-99de-85b6d2166863",
+                    "lsp_item_details": {
+                      "id": "same_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Same Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Same Day Delivery",
+                      "fulfillment_id": "0e71103f-54f5-4c36-99de-85b6d2166863",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "2.0"
+                    },
+                    "lsp_provider_id": "NS_LSP",
+                    "lsp_fulfillment_id": "ns_immediate_f1",
+                    "lsp_item_details": {
+                      "id": "ns_immediate",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "ns_immediate_f1",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "NS LSP Immediate Delivery",
+                        "short_desc": "Immediate Delivery by NS LSP",
+                        "long_desc": "Immediate Delivery by NS LSP"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2.0"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT55M",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    },
+                    "lsp_provider_id": "NS_LSP",
+                    "lsp_fulfillment_id": "ns_immediate_f1-RTO",
+                    "lsp_item_details": {
+                      "id": "ns_immediate-RTO",
+                      "parent_item_id": "ns_immediate",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "ns_immediate_f1-RTO",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "RTO quote",
+                        "short_desc": "RTO quote",
+                        "long_desc": "RTO quote"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "0"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT55M",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c70~19537~YAARI-19537-20250424-AI6VUITR7J~SY-1745516963204-764",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "395.74"
+                    },
+                    "lsp_provider_id": "19537",
+                    "lsp_fulfillment_id": "SY-1745516963204-764",
+                    "lsp_item_details": {
+                      "id": "YAARI-19537-20250424-AI6VUITR7J",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "SY-1745516963204-764",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Ecom Express",
+                        "short_desc": "Ecom Express",
+                        "long_desc": "Ecom Express"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "395.74"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a448665475e6bf8c71~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "815.00"
+                    },
+                    "lsp_provider_id": "DTDC",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "B2C SMART EXPRESS",
+                      "category_id": "Standard Delivery",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Standard Delivery",
+                        "short_desc": "B2C SMART EXPRESS",
+                        "long_desc": "3 - 4 Day/s"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "815.00"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P4D",
+                        "timestamp": "2025-04-28"
+                      },
+                      "fulfillment_id": "1"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a248665475e6bf8c64~I1~1~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a248665475e6bf8c64~I1~1~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a248665475e6bf8c64~I1~1~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a248665475e6bf8c67~P1~I1~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a248665475e6bf8c67~P1~I1~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a248665475e6bf8c67~P1~I1~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c69~MOVERDELIVERY~I1~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c69~MOVERDELIVERY~I1~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c69~MOVERDELIVERY~I1~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6b~Delhivery~55993af7-96f7-4dce-ac13-4c9132acf5af~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6b~Delhivery~55993af7-96f7-4dce-ac13-4c9132acf5af~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6b~Delhivery~55993af7-96f7-4dce-ac13-4c9132acf5af~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6c~P1~I1~I1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6c~P1~I1~I1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6c~P1~I1~I1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~9e41392a-f17e-449b-9fd3-6661a494f707",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~9e41392a-f17e-449b-9fd3-6661a494f707",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~9e41392a-f17e-449b-9fd3-6661a494f707",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~0e71103f-54f5-4c36-99de-85b6d2166863",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~0e71103f-54f5-4c36-99de-85b6d2166863",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~0e71103f-54f5-4c36-99de-85b6d2166863",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c70~19537~YAARI-19537-20250424-AI6VUITR7J~SY-1745516963204-764",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c70~19537~YAARI-19537-20250424-AI6VUITR7J~SY-1745516963204-764",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c70~19537~YAARI-19537-20250424-AI6VUITR7J~SY-1745516963204-764",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a448665475e6bf8c71~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a448665475e6bf8c71~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a448665475e6bf8c71~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "ttl": "P1D"
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "accept_bap_terms",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_select",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "3e91f782-7627-4849-8b5e-a745943b2fec",
+            "timestamp": "2025-04-24T17:49:29.643Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "init_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745517000\",expires=\"1745520600\",headers=\"(created) (expires) digest\",signature=\"Wvvsg+8zK/HiZd6IP8A0C0ZuTcMcoKF0coy4+c5kxB2GxK1aSVq3X/T8CniN2ZsHL9yuzz9A7jrTcSsCAvwVAw==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "722877fc-169b-4edb-af87-ec2d566f0f72",
+            "timestamp": "2025-04-24T17:50:00.982Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "ba9efae5-a00a-4c59-ac9c-347b00f12f62",
+            "timestamp": "2025-04-24T17:50:01.274Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_init_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517004\",expires=\"1745547004567\",headers=\"(created) (expires) digest\",signature=\"nXFGN30dj4PlwEl07Pkfs/gqQlK9dNEVROSjIdfZpkVg4B9IQNorH2sgkBQggMlRaQi7HUSUiIUZoUGws1p1BQ==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "722877fc-169b-4edb-af87-ec2d566f0f72",
+            "timestamp": "2025-04-24T17:50:04.555Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "currency": "INR",
+                  "amount": "0"
+                },
+                "status": "NOT-PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "return_window_expiry",
+                "@ondc/org/settlement_window": "P2D",
+                "@ondc/org/withholding_amount": "0",
+                "@ondc/org/collected_by_status": "Assert",
+                "collected_by": "BPP"
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "722877fc-169b-4edb-af87-ec2d566f0f72",
+            "timestamp": "2025-04-24T17:50:04.555Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "confirm_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745517217\",expires=\"1745520817\",headers=\"(created) (expires) digest\",signature=\"kbgtSMjhT1wKzberW1Bvqe36YWsAEGLeFdvW6zWxDEQuBn75G1fc7AbUBZLVJPNPoZ3M4IX2YtgIxA1ksGMLBg==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "confirm",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "3841f902-67f3-4b9f-b2e4-e442ec52a811",
+            "timestamp": "2025-04-24T17:53:37.464Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "Created",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "person": {
+                      "name": "Nirdosh Chauhan"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                },
+                {
+                  "code": "bap_terms",
+                  "list": [
+                    {
+                      "code": "tax_number",
+                      "value": "00XYZAB1234C1Z8"
+                    },
+                    {
+                      "code": "accept_bpp_terms",
+                      "value": "Y"
+                    }
+                  ]
+                }
+              ],
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Assert",
+                "collected_by": "BAP"
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:53:37.464Z"
+            }
+          }
+        },
+        "response": {
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_confirm_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517223\",expires=\"1745547223295\",headers=\"(created) (expires) digest\",signature=\"BsGEQ4ttLco01YLqGu8EeJUolrp+X54rob1/J0YFtJAZFG3bDYiBYt8PymdqBaZWAuZ0COGTQzjDte7AjNTMDw==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "3841f902-67f3-4b9f-b2e4-e442ec52a811",
+            "timestamp": "2025-04-24T17:53:43.287Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "Created",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T17:30:00.000Z",
+                        "end": "2025-04-24T19:30:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code",
+                      "long_desc": ""
+                    },
+                    "time": {
+                      "range": {
+                        "end": "2025-04-24T17:56:43.270Z"
+                      }
+                    }
+                  },
+                  "state": {
+                    "descriptor": {
+                      "code": "Pending",
+                      "name": "Getting ready for shipment (packaging)"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                },
+                {
+                  "code": "bap_terms",
+                  "list": [
+                    {
+                      "code": "tax_number",
+                      "value": "00XYZAB1234C1Z8"
+                    },
+                    {
+                      "code": "accept_bpp_terms",
+                      "value": "Y"
+                    }
+                  ]
+                }
+              ],
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Assert",
+                "collected_by": "BAP"
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:53:43.287Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "3841f902-67f3-4b9f-b2e4-e442ec52a811",
+            "timestamp": "2025-04-24T17:53:43.287Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517324\",expires=\"1745547324422\",headers=\"(created) (expires) digest\",signature=\"v47uT6R5vPTfngI4fIDnzypT88bP183RCSPZBoRW6rVQvJTDG/B8OAnUjoEIV+dS6T0Q/0usUcetqe/Z2hGfBA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "11e900c1-c7c0-43e0-a398-3cfd16031920",
+            "timestamp": "2025-04-24T17:55:24.412Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "Accepted",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T17:30:00.000Z",
+                        "end": "2025-04-24T19:30:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code",
+                      "long_desc": ""
+                    },
+                    "time": {
+                      "range": {
+                        "end": "2025-04-24T17:56:43.270Z"
+                      }
+                    }
+                  },
+                  "state": {
+                    "descriptor": {
+                      "code": "Pending",
+                      "name": "Getting ready for shipment (packaging)"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:55:24.351Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "11e900c1-c7c0-43e0-a398-3cfd16031920",
+            "timestamp": "2025-04-24T17:55:24.412Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_2": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517334\",expires=\"1745547334414\",headers=\"(created) (expires) digest\",signature=\"ot2nV8MvAOWgzz/l5iuS0K/Uu+twitj4VclgwysX75LiCC7wdliwpu5imrQ6W16lFJhroe2GYU09AJ7/tk1kCg==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "d7539474-cba5-43d1-8dcb-3b95d482863e",
+            "timestamp": "2025-04-24T17:55:34.406Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Packed",
+                      "name": "Packaging completed. Ready to ship"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:55:24.351Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "d7539474-cba5-43d1-8dcb-3b95d482863e",
+            "timestamp": "2025-04-24T17:55:34.406Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_3": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517342\",expires=\"1745547342940\",headers=\"(created) (expires) digest\",signature=\"iM57GKhIejgSA+eivCnxyU++sNHb3SohnMf0X7YxMSphiBBGM5E5VDQ5cnuLTWd/od+EcFfoEXvWsw3VqBdsCQ==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "a0b3d4d5-6983-4d51-b3fe-9ac289a9361c",
+            "timestamp": "2025-04-24T17:55:42.931Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Agent-assigned",
+                      "name": "Agent assigned"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:55:24.351Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "a0b3d4d5-6983-4d51-b3fe-9ac289a9361c",
+            "timestamp": "2025-04-24T17:55:42.931Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_4": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517357\",expires=\"1745547357672\",headers=\"(created) (expires) digest\",signature=\"+xDzCwy844elh62tPLgMAoZnsb175qWkmRYPyouf/r/Eh1gUbwv0hEIEMWU+z2ahKisTn5Sl03wUYf/IWUAeDQ==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "99f1e53c-ade7-4dd9-991e-cd6423698143",
+            "timestamp": "2025-04-24T17:55:57.659Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-picked-up",
+                      "name": "Product picked up from the source and shipment started"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:55:57.504Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:55:24.351Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "99f1e53c-ade7-4dd9-991e-cd6423698143",
+            "timestamp": "2025-04-24T17:55:57.659Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_5": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517363\",expires=\"1745547363701\",headers=\"(created) (expires) digest\",signature=\"Zg0fGILhWtpQh9uUByJzyyxmYuEFAAlBtWFLBTE91U4442cRu/H1Yz4Y7p2X8b65zOsAQzqJidx1w0eWv7YYBw==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "03bfe26a-b46a-4b86-b363-05303b8f4c9c",
+            "timestamp": "2025-04-24T17:56:03.689Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Out-for-delivery",
+                      "name": "Product would be delivered soon"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:55:57.504Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:55:24.351Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "03bfe26a-b46a-4b86-b363-05303b8f4c9c",
+            "timestamp": "2025-04-24T17:56:03.689Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_6": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517379\",expires=\"1745547379239\",headers=\"(created) (expires) digest\",signature=\"JnPh2ATHjdKD7EGUWb5+lxYo2JwyDHlfvuOpEvVxDjxnykzsr4J1XmeyIZteaPtrGyIZ8JPHW5XQ6p87v/zCDA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "2c330ebb-7daa-453c-9485-9fa142390b08",
+            "timestamp": "2025-04-24T17:56:19.232Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Out-for-delivery",
+                      "name": "Product would be delivered soon"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:55:57.504Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:55:24.351Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "2c330ebb-7daa-453c-9485-9fa142390b08",
+            "timestamp": "2025-04-24T17:56:19.232Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_cancel_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517390\",expires=\"1745547390485\",headers=\"(created) (expires) digest\",signature=\"rKbgs0Dc/N0CJKS9ZADdbjBMkYzUmm5RqMliGw4TymqqZmbjhmxe8r0jb30U1Be9wv87TCiyypiE4aJMjsrWBA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_cancel",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "2c330ebb-7daa-453c-9485-9fa142390b08",
+            "timestamp": "2025-04-24T17:56:30.403Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "Cancelled",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": "0"
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": "0"
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "fulfillment_id": "C1680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "quantity": {
+                    "count": "0"
+                  }
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "fulfillment_id": "C1680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "quantity": {
+                    "count": "0"
+                  }
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Cancelled",
+                      "name": "Product cancellation"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:55:57.504Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "precancel_state",
+                      "list": [
+                        {
+                          "code": "fulfillment_state",
+                          "value": "Out-for-delivery"
+                        },
+                        {
+                          "code": "updated_at",
+                          "value": "2025-04-24T17:56:03.540Z"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_event",
+                      "list": [
+                        {
+                          "code": "rto_id",
+                          "value": "968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                        },
+                        {
+                          "code": "cancellation_reason_id",
+                          "value": "016"
+                        },
+                        {
+                          "code": "cancelled_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                        },
+                        {
+                          "code": "retry_count",
+                          "value": "2"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "cancel_request",
+                      "list": [
+                        {
+                          "code": "retry_count",
+                          "value": "2"
+                        },
+                        {
+                          "code": "rto_id",
+                          "value": "RTO0968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                        },
+                        {
+                          "code": "reason_id",
+                          "value": ""
+                        },
+                        {
+                          "code": "initiated_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                },
+                {
+                  "id": "RTO0968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                  "type": "RTO",
+                  "state": {
+                    "descriptor": {
+                      "code": "RTO-Initiated"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T17:56:28.834Z",
+                        "end": "2025-04-24T17:56:28.834Z"
+                      },
+                      "timestamp": "2025-04-24T17:56:28.834Z"
+                    },
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "7915.62"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    },
+                    "@ondc/org/item_id": "rto_std",
+                    "@ondc/org/title_type": "rto"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "rto_std",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:55:24.351Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_cancel",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "2c330ebb-7daa-453c-9485-9fa142390b08",
+            "timestamp": "2025-04-24T17:56:30.403Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_7": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517431\",expires=\"1745547431927\",headers=\"(created) (expires) digest\",signature=\"05ktX+fn3ghLPon8XnCynE8Rf1nDjvnyvsRjj8GGDFRTpfMXQrfYtrkelY3YPSTRonEJQ4nvdvOatRakD9DwAA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "c2c711a3-d6ae-4249-814e-965e81337b67",
+            "timestamp": "2025-04-24T17:57:11.917Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": "0"
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": "0"
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "fulfillment_id": "C1680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "quantity": {
+                    "count": "0"
+                  }
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "fulfillment_id": "C1680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "quantity": {
+                    "count": "0"
+                  }
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Cancelled",
+                      "name": "Product cancellation"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:55:57.504Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "precancel_state",
+                      "list": [
+                        {
+                          "code": "fulfillment_state",
+                          "value": "Out-for-delivery"
+                        },
+                        {
+                          "code": "updated_at",
+                          "value": "2025-04-24T17:56:03.540Z"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_event",
+                      "list": [
+                        {
+                          "code": "rto_id",
+                          "value": "968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                        },
+                        {
+                          "code": "cancellation_reason_id",
+                          "value": "016"
+                        },
+                        {
+                          "code": "cancelled_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                        },
+                        {
+                          "code": "retry_count",
+                          "value": "2"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "cancel_request",
+                      "list": [
+                        {
+                          "code": "retry_count",
+                          "value": "2"
+                        },
+                        {
+                          "code": "rto_id",
+                          "value": "RTO0968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                        },
+                        {
+                          "code": "reason_id",
+                          "value": ""
+                        },
+                        {
+                          "code": "initiated_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                },
+                {
+                  "id": "RTO0968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                  "type": "RTO",
+                  "state": {
+                    "descriptor": {
+                      "code": "RTO-Delivered",
+                      "name": "The order delivered back to the source as the customer refused to accept the order"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T17:56:28.834Z",
+                        "end": "2025-04-24T17:56:28.834Z"
+                      },
+                      "timestamp": "2025-04-24T17:56:28.834Z"
+                    },
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "timestamp": "2025-04-24T17:57:11.747Z"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "7915.62"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    },
+                    "@ondc/org/item_id": "rto_std",
+                    "@ondc/org/title_type": "rto"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "rto_std",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:55:24.351Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "c2c711a3-d6ae-4249-814e-965e81337b67",
+            "timestamp": "2025-04-24T17:57:11.917Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_8": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517488\",expires=\"1745547488011\",headers=\"(created) (expires) digest\",signature=\"mW2NjgCg9g5FR5qgqjB2cO47q3PiNPD59trcIK33NuMnsc5AvauAlTbEGOe/lno48XBwxtz5cCR83I5KOsn9CQ==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "96adeb6c-a0d4-4695-a51a-0cf0b7567aed",
+            "timestamp": "2025-04-24T17:58:07.999Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517217464",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": "0"
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": "0"
+                  },
+                  "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+                },
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "fulfillment_id": "C1680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "quantity": {
+                    "count": "0"
+                  }
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "fulfillment_id": "C1680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "quantity": {
+                    "count": "0"
+                  }
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:50:00.982Z",
+                "updated_at": "2025-04-24T17:50:00.982Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Cancelled",
+                      "name": "Product cancellation"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:55:57.504Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "precancel_state",
+                      "list": [
+                        {
+                          "code": "fulfillment_state",
+                          "value": "Out-for-delivery"
+                        },
+                        {
+                          "code": "updated_at",
+                          "value": "2025-04-24T17:56:03.540Z"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_event",
+                      "list": [
+                        {
+                          "code": "rto_id",
+                          "value": "968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                        },
+                        {
+                          "code": "cancellation_reason_id",
+                          "value": "016"
+                        },
+                        {
+                          "code": "cancelled_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                        },
+                        {
+                          "code": "retry_count",
+                          "value": "2"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "cancel_request",
+                      "list": [
+                        {
+                          "code": "retry_count",
+                          "value": "2"
+                        },
+                        {
+                          "code": "rto_id",
+                          "value": "RTO0968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                        },
+                        {
+                          "code": "reason_id",
+                          "value": ""
+                        },
+                        {
+                          "code": "initiated_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                },
+                {
+                  "id": "RTO0968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                  "type": "RTO",
+                  "state": {
+                    "descriptor": {
+                      "code": "RTO-Delivered",
+                      "name": "The order delivered back to the source as the customer refused to accept the order"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T17:56:28.834Z",
+                        "end": "2025-04-24T17:56:28.834Z"
+                      },
+                      "timestamp": "2025-04-24T17:56:28.834Z"
+                    },
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "timestamp": "2025-04-24T17:57:11.747Z"
+                    }
+                  },
+                  "tags": null
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "7915.62"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    },
+                    "@ondc/org/item_id": "rto_std",
+                    "@ondc/org/title_type": "rto"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "rto_std",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:53:37.464Z",
+              "updated_at": "2025-04-24T17:55:24.351Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+            "message_id": "96adeb6c-a0d4-4695-a51a-0cf0b7567aed",
+            "timestamp": "2025-04-24T17:58:07.999Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      }
+    }
+  }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_confirm.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_confirm.json
@@ -1,0 +1,238 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "confirm",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "2c30dcc9-aace-442f-926e-d046fd12ee95",
+          "timestamp": "2025-04-24T17:53:38.090Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "category_id": "Standard Delivery",
+                "descriptor": {
+                  "code": "P2P"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "id": "SS1745517217464",
+            "state": "Created",
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517217464",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "tags": [
+              {
+                "code": "bap_terms",
+                "list": [
+                  {
+                    "code": "accept_bpp_terms",
+                    "value": "Y"
+                  }
+                ]
+              }
+            ],
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:53:38.051Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_init.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_init.json
@@ -1,0 +1,97 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "init",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "ba9efae5-a00a-4c59-ac9c-347b00f12f62",
+          "timestamp": "2025-04-24T17:50:01.274Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "category_id": "Standard Delivery",
+                "descriptor": {
+                  "code": "P2P"
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_cancel_rto_initiated.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_cancel_rto_initiated.json
@@ -1,0 +1,409 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_cancel",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "f5d994d5-c4d0-4c09-8160-2a3877968e28",
+          "timestamp": "2025-04-24T17:56:28.834Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT100S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "Cancelled",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "rto_std",
+                "parent_item_id": "std_del",
+                "category_id": "Standard Delivery",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                },
+                "price": {
+                  "currency": "INR",
+                  "value": "2612.06"
+                }
+              },
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Cancelled"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:55:57.504Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "precancel_state",
+                    "list": [
+                      {
+                        "code": "fulfillment_state",
+                        "value": "Out-for-delivery"
+                      },
+                      {
+                        "code": "updated_at",
+                        "value": "2025-04-24T17:56:03.540Z"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_event",
+                    "list": [
+                      {
+                        "code": "rto_id",
+                        "value": "968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                      },
+                      {
+                        "code": "cancellation_reason_id",
+                        "value": "016"
+                      },
+                      {
+                        "code": "cancelled_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                      },
+                      {
+                        "code": "retry_count",
+                        "value": "2"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              },
+              {
+                "id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                "type": "RTO",
+                "state": {
+                  "descriptor": {
+                    "code": "RTO-Initiated"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T17:56:28.834Z",
+                      "end": "2025-04-24T17:56:28.834Z"
+                    },
+                    "timestamp": "2025-04-24T17:56:28.834Z"
+                  },
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "7816"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                },
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "2612.06"
+                  },
+                  "@ondc/org/item_id": "rto_std",
+                  "@ondc/org/title_type": "rto"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "rto_std",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "status": "NOT-PAID"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517217464",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:56:28.834Z",
+            "cancellation": {
+              "cancelled_by": "pramaan.ondc.org/beta/preprod/mock/seller",
+              "reason": {
+                "id": "016"
+              }
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_confirm.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_confirm.json
@@ -1,0 +1,240 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_confirm",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "2c30dcc9-aace-442f-926e-d046fd12ee95",
+          "timestamp": "2025-04-24T17:53:38.138Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT10M"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "Accepted",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Pending"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517217464",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:53:38.138Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_init.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_init.json
@@ -1,0 +1,102 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_init",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "ba9efae5-a00a-4c59-ac9c-347b00f12f62",
+          "timestamp": "2025-04-24T17:50:01.316Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT10M"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                }
+              }
+            ],
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ],
+              "ttl": "P7D"
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_search.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_search.json
@@ -1,0 +1,414 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_search",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "6546e60f-bb01-4557-a8f4-84c272ee19fd",
+          "timestamp": "2025-04-24T17:49:23.159Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT30S",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+        },
+        "message": {
+          "catalog": {
+            "bpp/descriptor": {
+              "name": "ONDC Pramaaan Logistics"
+            },
+            "bpp/providers": [
+              {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                "descriptor": {
+                  "name": "ONDC Pramaaan Logistics",
+                  "short_desc": "Swiftly Yours, Delivered with Care",
+                  "long_desc": "We deliver everywhere—yes, even Mars (just give us a little more rocket fuel)."
+                },
+                "categories": [
+                  {
+                    "id": "Standard Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "Immediate Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2025-04-24"
+                    }
+                  },
+                  {
+                    "id": "Express Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "Next Day Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "Same Day Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT4H",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                ],
+                "fulfillments": [
+                  {
+                    "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT15M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT20M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "9e41392a-f17e-449b-9fd3-6661a494f707",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT30M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT30M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "0e71103f-54f5-4c36-99de-85b6d2166863",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT15M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                    "type": "RTO"
+                  }
+                ],
+                "items": [
+                  {
+                    "id": "rto_std",
+                    "parent_item_id": "std_del",
+                    "category_id": "Standard Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "rto_imd",
+                    "parent_item_id": "imd_del",
+                    "category_id": "Immediate Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Immediate Delivery",
+                      "long_desc": "Upto 60 mins for Delivery",
+                      "short_desc": "Upto 60 mins for Delivery"
+                    },
+                    "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2025-04-24"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "imd_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Immediate Delivery",
+                      "long_desc": "Upto 60 mins for Delivery",
+                      "short_desc": "Upto 60 mins for Delivery"
+                    },
+                    "category_id": "Immediate Delivery",
+                    "fulfillment_id": "9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2025-04-24"
+                    }
+                  },
+                  {
+                    "id": "rto_exp",
+                    "parent_item_id": "exp_del",
+                    "category_id": "Express Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Express Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "exp_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Express Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Express Delivery",
+                    "fulfillment_id": "9e41392a-f17e-449b-9fd3-6661a494f707",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "rto_nex",
+                    "parent_item_id": "nex_del",
+                    "category_id": "Next Day Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Next Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "nex_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Next Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Next Day Delivery",
+                    "fulfillment_id": "aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "rto_same",
+                    "parent_item_id": "same_del",
+                    "category_id": "Same Day Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Same Day Delivery",
+                      "long_desc": "Same Delivery",
+                      "short_desc": "Same for Delivery"
+                    },
+                    "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT4H",
+                      "timestamp": "2025-04-24"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "same_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Same Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Same Day Delivery",
+                    "fulfillment_id": "0e71103f-54f5-4c36-99de-85b6d2166863",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT4H",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_status_1_agent_assigned.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_status_1_agent_assigned.json
@@ -1,0 +1,253 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "9793b10a-3048-44ed-a2cd-17651bb6a425",
+          "timestamp": "2025-04-24T17:55:42.774Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT50S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "In-progress",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Agent-assigned"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517217464",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:55:42.774Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_status_2_picked_up.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_status_2_picked_up.json
@@ -1,0 +1,278 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "fe4079a9-acfa-40c8-b382-d86c6d5e898b",
+          "timestamp": "2025-04-24T17:55:57.504Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT50S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "In-progress",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-picked-up"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:55:57.504Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "status": "NOT-PAID"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517217464",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:55:57.504Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_status_3_out_for_delivery.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_status_3_out_for_delivery.json
@@ -1,0 +1,278 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "aa0004c8-e507-47c3-adf5-201341d9ec7f",
+          "timestamp": "2025-04-24T17:56:03.540Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT50S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "In-progress",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Out-for-delivery"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:55:57.504Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "status": "NOT-PAID"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517217464",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:56:03.540Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_status_4_response.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_status_4_response.json
@@ -1,0 +1,278 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "926cf1b1-e36a-466f-be98-e6af2ac74f04",
+          "timestamp": "2025-04-24T17:56:19.084Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT10M"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "In-progress",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Out-for-delivery"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:55:57.504Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "status": "NOT-PAID"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517217464",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:56:03.540Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_status_5_rto_delivered.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_status_5_rto_delivered.json
@@ -1,0 +1,412 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "2776e315-023e-46a7-b89a-d6cdd8b92889",
+          "timestamp": "2025-04-24T17:57:11.747Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT100S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "Cancelled",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "rto_std",
+                "parent_item_id": "std_del",
+                "category_id": "Standard Delivery",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                },
+                "price": {
+                  "currency": "INR",
+                  "value": "2612.06"
+                }
+              },
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Cancelled"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:55:57.504Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "precancel_state",
+                    "list": [
+                      {
+                        "code": "fulfillment_state",
+                        "value": "Out-for-delivery"
+                      },
+                      {
+                        "code": "updated_at",
+                        "value": "2025-04-24T17:56:03.540Z"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_event",
+                    "list": [
+                      {
+                        "code": "rto_id",
+                        "value": "968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                      },
+                      {
+                        "code": "cancellation_reason_id",
+                        "value": "016"
+                      },
+                      {
+                        "code": "cancelled_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                      },
+                      {
+                        "code": "retry_count",
+                        "value": "2"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              },
+              {
+                "id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                "type": "RTO",
+                "state": {
+                  "descriptor": {
+                    "code": "RTO-Delivered"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T17:56:28.834Z",
+                      "end": "2025-04-24T17:56:28.834Z"
+                    },
+                    "timestamp": "2025-04-24T17:56:28.834Z"
+                  },
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "timestamp": "2025-04-24T17:57:11.747Z"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "7816"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                },
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "2612.06"
+                  },
+                  "@ondc/org/item_id": "rto_std",
+                  "@ondc/org/title_type": "rto"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "rto_std",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "status": "NOT-PAID"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517217464",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:56:28.834Z",
+            "cancellation": {
+              "cancelled_by": "pramaan.ondc.org/beta/preprod/mock/seller",
+              "reason": {
+                "id": "016"
+              }
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_status_6_response.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_status_6_response.json
@@ -1,0 +1,412 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "41c45b11-2c48-41e5-af04-6bbd16bea54b",
+          "timestamp": "2025-04-24T17:58:07.849Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT10M"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "Cancelled",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "rto_std",
+                "parent_item_id": "std_del",
+                "category_id": "Standard Delivery",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "fulfillment_id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                },
+                "price": {
+                  "currency": "INR",
+                  "value": "2612.06"
+                }
+              },
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Cancelled"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:55:57.504Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "precancel_state",
+                    "list": [
+                      {
+                        "code": "fulfillment_state",
+                        "value": "Out-for-delivery"
+                      },
+                      {
+                        "code": "updated_at",
+                        "value": "2025-04-24T17:56:03.540Z"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_event",
+                    "list": [
+                      {
+                        "code": "rto_id",
+                        "value": "968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                      },
+                      {
+                        "code": "cancellation_reason_id",
+                        "value": "016"
+                      },
+                      {
+                        "code": "cancelled_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                      },
+                      {
+                        "code": "retry_count",
+                        "value": "2"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              },
+              {
+                "id": "968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                "type": "RTO",
+                "state": {
+                  "descriptor": {
+                    "code": "RTO-Delivered"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T17:56:28.834Z",
+                      "end": "2025-04-24T17:56:28.834Z"
+                    },
+                    "timestamp": "2025-04-24T17:56:28.834Z"
+                  },
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "timestamp": "2025-04-24T17:57:11.747Z"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "7816"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                },
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "2612.06"
+                  },
+                  "@ondc/org/item_id": "rto_std",
+                  "@ondc/org/title_type": "rto"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "rto_std",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "status": "NOT-PAID"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517217464",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:56:28.834Z",
+            "cancellation": {
+              "cancelled_by": "pramaan.ondc.org/beta/preprod/mock/seller",
+              "reason": {
+                "id": "016"
+              }
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_update.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_on_update.json
@@ -1,0 +1,246 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_update",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "ff539e77-e633-4b18-a8f3-2a8768f770ea",
+          "timestamp": "2025-04-24T17:55:34.255Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT10M"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "Accepted",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Searching-for-Agent"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517217464",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:53:38.138Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_search.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_search.json
@@ -1,0 +1,83 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "search",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "6546e60f-bb01-4557-a8f4-84c272ee19fd",
+          "timestamp": "2025-04-24T17:49:21.863Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "intent": {
+            "category": {
+              "id": "Standard Delivery"
+            },
+            "provider": {
+              "time": {
+                "days": "1,2,3,4,5,6,7",
+                "schedule": {
+                  "holidays": []
+                },
+                "duration": "P0DT0H1M",
+                "range": {
+                  "start": "0001",
+                  "end": "2359"
+                }
+              }
+            },
+            "fulfillment": {
+              "type": "Delivery",
+              "start": {
+                "location": {
+                  "gps": "12.9263841,77.6654374",
+                  "address": {
+                    "area_code": "560103"
+                  }
+                }
+              },
+              "end": {
+                "location": {
+                  "gps": "28.4554726,77.0219019",
+                  "address": {
+                    "area_code": "122007"
+                  }
+                }
+              }
+            },
+            "payment": {
+              "type": "ON-ORDER"
+            },
+            "@ondc/org/payload_details": {
+              "weight": {
+                "unit": "gram",
+                "value": 1720
+              },
+              "dimensions": {
+                "length": {
+                  "unit": "centimeter",
+                  "value": 119
+                },
+                "breadth": {
+                  "unit": "centimeter",
+                  "value": 35
+                },
+                "height": {
+                  "unit": "centimeter",
+                  "value": 25
+                }
+              },
+              "category": "Grocery",
+              "value": {
+                "currency": "INR",
+                "value": "880"
+              },
+              "dangerous_goods": false
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_status_1_request.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_status_1_request.json
@@ -1,0 +1,20 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "926cf1b1-e36a-466f-be98-e6af2ac74f04",
+          "timestamp": "2025-04-24T17:56:17.609Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order_id": "SS1745517217464"
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_status_2_request.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_status_2_request.json
@@ -1,0 +1,20 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "41c45b11-2c48-41e5-af04-6bbd16bea54b",
+          "timestamp": "2025-04-24T17:58:06.042Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order_id": "SS1745517217464"
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_update.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/LBNP_update.json
@@ -1,0 +1,90 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "update",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "ff539e77-e633-4b18-a8f3-2a8768f770ea",
+          "timestamp": "2025-04-24T17:55:32.796Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "update_target": "fulfillment",
+          "order": {
+            "id": "SS1745517217464",
+            "state": "Created",
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "descriptor": {
+                  "code": "P2P"
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship",
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "updated_at": "2025-04-24T23:25:32.785Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_confirm.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_confirm.json
@@ -1,0 +1,335 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "confirm",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "3841f902-67f3-4b9f-b2e4-e442ec52a811",
+          "timestamp": "2025-04-24T17:53:37.464Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "Created",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D",
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": "other pickup confirmation code",
+                    "long_desc": "Pls pickup orders from counter number 01."
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "person": {
+                    "name": "Nirdosh Chauhan"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "tags": [
+              {
+                "code": "bpp_terms",
+                "list": [
+                  {
+                    "code": "np_type",
+                    "value": "MSN"
+                  },
+                  {
+                    "code": "collect_payment",
+                    "value": "Y"
+                  },
+                  {
+                    "code": "max_liability",
+                    "value": "2"
+                  },
+                  {
+                    "code": "max_liability_cap",
+                    "value": "10000"
+                  },
+                  {
+                    "code": "mandatory_arbitration",
+                    "value": "false"
+                  },
+                  {
+                    "code": "court_jurisdiction",
+                    "value": "Bengaluru"
+                  },
+                  {
+                    "code": "delay_interest",
+                    "value": "7"
+                  },
+                  {
+                    "code": "tax_number",
+                    "value": "29ABGCS7802J1ZX"
+                  },
+                  {
+                    "code": "provider_tax_number",
+                    "value": "ABGCS7802J"
+                  }
+                ]
+              },
+              {
+                "code": "bap_terms",
+                "list": [
+                  {
+                    "code": "tax_number",
+                    "value": "00XYZAB1234C1Z8"
+                  },
+                  {
+                    "code": "accept_bpp_terms",
+                    "value": "Y"
+                  }
+                ]
+              }
+            ],
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Assert",
+              "collected_by": "BAP"
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:53:37.464Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_init.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_init.json
@@ -1,0 +1,88 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "init",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "722877fc-169b-4edb-af87-ec2d566f0f72",
+          "timestamp": "2025-04-24T17:50:00.982Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "ttl": "PT30S",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_cancel_rto_initiated.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_cancel_rto_initiated.json
@@ -1,0 +1,484 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_cancel",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "2c330ebb-7daa-453c-9485-9fa142390b08",
+          "timestamp": "2025-04-24T17:56:30.403Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "Cancelled",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": "0"
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": "0"
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "fulfillment_id": "C1680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "quantity": {
+                  "count": "0"
+                }
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "fulfillment_id": "C1680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "quantity": {
+                  "count": "0"
+                }
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Cancelled",
+                    "name": "Product cancellation"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:55:57.504Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "precancel_state",
+                    "list": [
+                      {
+                        "code": "fulfillment_state",
+                        "value": "Out-for-delivery"
+                      },
+                      {
+                        "code": "updated_at",
+                        "value": "2025-04-24T17:56:03.540Z"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_event",
+                    "list": [
+                      {
+                        "code": "rto_id",
+                        "value": "968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                      },
+                      {
+                        "code": "cancellation_reason_id",
+                        "value": "016"
+                      },
+                      {
+                        "code": "cancelled_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                      },
+                      {
+                        "code": "retry_count",
+                        "value": "2"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "cancel_request",
+                    "list": [
+                      {
+                        "code": "retry_count",
+                        "value": "2"
+                      },
+                      {
+                        "code": "rto_id",
+                        "value": "RTO0968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                      },
+                      {
+                        "code": "reason_id",
+                        "value": ""
+                      },
+                      {
+                        "code": "initiated_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              },
+              {
+                "id": "RTO0968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                "type": "RTO",
+                "state": {
+                  "descriptor": {
+                    "code": "RTO-Initiated"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T17:56:28.834Z",
+                      "end": "2025-04-24T17:56:28.834Z"
+                    },
+                    "timestamp": "2025-04-24T17:56:28.834Z"
+                  },
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "7915.62"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "2612.06"
+                  },
+                  "@ondc/org/item_id": "rto_std",
+                  "@ondc/org/title_type": "rto"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "rto_std",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:55:24.351Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_confirm.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_confirm.json
@@ -1,0 +1,354 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_confirm",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "3841f902-67f3-4b9f-b2e4-e442ec52a811",
+          "timestamp": "2025-04-24T17:53:43.287Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "Created",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D",
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": "other pickup confirmation code",
+                    "long_desc": "Pls pickup orders from counter number 01."
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T17:30:00.000Z",
+                      "end": "2025-04-24T19:30:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "instructions": {
+                    "name": "Proof of delivery",
+                    "code": "3",
+                    "short_desc": "no delivery code",
+                    "long_desc": ""
+                  },
+                  "time": {
+                    "range": {
+                      "end": "2025-04-24T17:56:43.270Z"
+                    }
+                  }
+                },
+                "state": {
+                  "descriptor": {
+                    "code": "Pending",
+                    "name": "Getting ready for shipment (packaging)"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "tags": [
+              {
+                "code": "bpp_terms",
+                "list": [
+                  {
+                    "code": "np_type",
+                    "value": "MSN"
+                  },
+                  {
+                    "code": "collect_payment",
+                    "value": "Y"
+                  },
+                  {
+                    "code": "max_liability",
+                    "value": "2"
+                  },
+                  {
+                    "code": "max_liability_cap",
+                    "value": "10000"
+                  },
+                  {
+                    "code": "mandatory_arbitration",
+                    "value": "false"
+                  },
+                  {
+                    "code": "court_jurisdiction",
+                    "value": "Bengaluru"
+                  },
+                  {
+                    "code": "delay_interest",
+                    "value": "7"
+                  },
+                  {
+                    "code": "tax_number",
+                    "value": "29ABGCS7802J1ZX"
+                  },
+                  {
+                    "code": "provider_tax_number",
+                    "value": "ABGCS7802J"
+                  }
+                ]
+              },
+              {
+                "code": "bap_terms",
+                "list": [
+                  {
+                    "code": "tax_number",
+                    "value": "00XYZAB1234C1Z8"
+                  },
+                  {
+                    "code": "accept_bpp_terms",
+                    "value": "Y"
+                  }
+                ]
+              }
+            ],
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Assert",
+              "collected_by": "BAP"
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:53:43.287Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_init.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_init.json
@@ -1,0 +1,313 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_init",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "722877fc-169b-4edb-af87-ec2d566f0f72",
+          "timestamp": "2025-04-24T17:50:04.555Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D",
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": "other pickup confirmation code",
+                    "long_desc": "Pls pickup orders from counter number 01."
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "currency": "INR",
+                "amount": "0"
+              },
+              "status": "NOT-PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "return_window_expiry",
+              "@ondc/org/settlement_window": "P2D",
+              "@ondc/org/withholding_amount": "0",
+              "@ondc/org/collected_by_status": "Assert",
+              "collected_by": "BPP"
+            },
+            "tags": [
+              {
+                "code": "bpp_terms",
+                "list": [
+                  {
+                    "code": "np_type",
+                    "value": "MSN"
+                  },
+                  {
+                    "code": "collect_payment",
+                    "value": "Y"
+                  },
+                  {
+                    "code": "max_liability",
+                    "value": "2"
+                  },
+                  {
+                    "code": "max_liability_cap",
+                    "value": "10000"
+                  },
+                  {
+                    "code": "mandatory_arbitration",
+                    "value": "false"
+                  },
+                  {
+                    "code": "court_jurisdiction",
+                    "value": "Bengaluru"
+                  },
+                  {
+                    "code": "delay_interest",
+                    "value": "7"
+                  },
+                  {
+                    "code": "tax_number",
+                    "value": "29ABGCS7802J1ZX"
+                  },
+                  {
+                    "code": "provider_tax_number",
+                    "value": "ABGCS7802J"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_search.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_search.json
@@ -1,0 +1,1396 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_search",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "98e7e7ab-95f9-43fb-b8b8-7b5dc990820e",
+          "timestamp": "2025-04-24T17:48:58.096Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "ttl": "PT30S",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "catalog": {
+            "bpp/fulfillments": [
+              {
+                "id": "1",
+                "type": "Delivery",
+                "contact": {
+                  "phone": "9900025784",
+                  "email": "sgupta.scm@gmail.com"
+                }
+              }
+            ],
+            "bpp/descriptor": {
+              "name": "Lekhha",
+              "symbol": "https://lekhha.com/wp-content/uploads/2023/07/logo-light-1.png",
+              "short_desc": "App-based platform for order and inventory management.",
+              "long_desc": "LEKHHA is a simple solution to help you comprehensively run your business operations. Discover it to also track & manage your personal needs & resources. Reach out to us to serve you as your solution partner.",
+              "images": [
+                "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/logo",
+                "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/vendor",
+                "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/consumer",
+                "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/inventory"
+              ],
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    }
+                  ]
+                }
+              ]
+            },
+            "bpp/providers": [
+              {
+                "id": "674ecb33d7b9e10f4210d972",
+                "time": {
+                  "label": "enable",
+                  "timestamp": "2025-04-24T17:48:57.338Z"
+                },
+                "descriptor": {
+                  "name": "Lekhha Provider A",
+                  "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecb33d7b9e10f4210d972_S",
+                  "short_desc": "Lekhha_Seller_1 kyc short",
+                  "long_desc": "Lekhha_Seller_1 kyc long",
+                  "images": [
+                    "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecb33d7b9e10f4210d972"
+                  ]
+                },
+                "ttl": "P1D",
+                "creds": [
+                  {
+                    "descriptor": {
+                      "code": "Lekhha_Seller_1_cred1",
+                      "name": "Lekhha_Seller_1 cred1",
+                      "short_desc": "Lekhha_Seller_1 cred1 short"
+                    },
+                    "id": "674ecbc6d7b9e10f4210d973_1",
+                    "tags": [
+                      {
+                        "code": "verification",
+                        "list": [
+                          {
+                            "code": "verify_url",
+                            "value": "https://url1url.com/verify1"
+                          },
+                          {
+                            "code": "valid_from",
+                            "value": "2024-12-09T00:00:00.000Z"
+                          },
+                          {
+                            "code": "valid_to",
+                            "value": "2027-03-31T00:00:00.000Z"
+                          }
+                        ]
+                      }
+                    ],
+                    "url": "https://url1url.com"
+                  }
+                ],
+                "fulfillments": [
+                  {
+                    "id": "1",
+                    "type": "Delivery",
+                    "contact": {
+                      "phone": "9900025784",
+                      "email": "sgupta.scm@gmail.com"
+                    }
+                  }
+                ],
+                "tags": [
+                  {
+                    "code": "order_value",
+                    "list": [
+                      {
+                        "code": "min_value",
+                        "value": "150.5"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "timing",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "Order"
+                      },
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "day_from",
+                        "value": "1"
+                      },
+                      {
+                        "code": "day_to",
+                        "value": "7"
+                      },
+                      {
+                        "code": "time_from",
+                        "value": "0001"
+                      },
+                      {
+                        "code": "time_to",
+                        "value": "2359"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "timing",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "Delivery"
+                      },
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "day_from",
+                        "value": "1"
+                      },
+                      {
+                        "code": "day_to",
+                        "value": "7"
+                      },
+                      {
+                        "code": "time_from",
+                        "value": "0001"
+                      },
+                      {
+                        "code": "time_to",
+                        "value": "2359"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "timing",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "Self-Pickup"
+                      },
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "day_from",
+                        "value": "1"
+                      },
+                      {
+                        "code": "day_to",
+                        "value": "7"
+                      },
+                      {
+                        "code": "time_from",
+                        "value": "0001"
+                      },
+                      {
+                        "code": "time_to",
+                        "value": "2359"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "serviceability",
+                    "list": [
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "category",
+                        "value": "Bakery, Cakes & Dairy"
+                      },
+                      {
+                        "code": "type",
+                        "value": "11"
+                      },
+                      {
+                        "code": "val",
+                        "value": "100000-999999"
+                      },
+                      {
+                        "code": "unit",
+                        "value": "pincode"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "serviceability",
+                    "list": [
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "category",
+                        "value": "Energy and Soft Drinks"
+                      },
+                      {
+                        "code": "type",
+                        "value": "11"
+                      },
+                      {
+                        "code": "val",
+                        "value": "100000-999999"
+                      },
+                      {
+                        "code": "unit",
+                        "value": "pincode"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "serviceability",
+                    "list": [
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "category",
+                        "value": "Fruits and Vegetables"
+                      },
+                      {
+                        "code": "type",
+                        "value": "11"
+                      },
+                      {
+                        "code": "val",
+                        "value": "100000-999999"
+                      },
+                      {
+                        "code": "unit",
+                        "value": "pincode"
+                      }
+                    ]
+                  }
+                ],
+                "items": [
+                  {
+                    "id": "676a61f6cac4860876a8e30f",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:48:57.596Z"
+                    },
+                    "parent_item_id": "V10000000001",
+                    "descriptor": {
+                      "name": "Milk orange",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Milk orange short",
+                      "long_desc": "Milk orange long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e3_0"
+                      ],
+                      "code": "1:1000000000232"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "13"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "49.82",
+                      "maximum_value": "53.00"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 11",
+                      "additives_info": "additives info 11",
+                      "brand_owner_FSSAI_license_no": "fssai license 11",
+                      "other_FSSAI_license_no": "other license 11",
+                      "importer_FSSAI_license_no": "importer license 11"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 11",
+                      "manufacturer_or_packer_address": "address 11",
+                      "common_or_generic_name_of_commodity": "commodity 11",
+                      "month_year_of_manufacture_packing_import": "year 11"
+                    }
+                  },
+                  {
+                    "id": "676a6179cac4860876a8e30b",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:48:57.631Z"
+                    },
+                    "parent_item_id": "V10000000002",
+                    "descriptor": {
+                      "name": "Milk blue",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Milk blue short",
+                      "long_desc": "Milk blue long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e5_0"
+                      ],
+                      "code": "1:1000000000233"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "10"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "12"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.00",
+                      "maximum_value": "400.00"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 9",
+                      "additives_info": "additives info 9",
+                      "brand_owner_FSSAI_license_no": "fssai license 9",
+                      "other_FSSAI_license_no": "other license 9",
+                      "importer_FSSAI_license_no": "importer license 9"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 9",
+                      "manufacturer_or_packer_address": "address 9",
+                      "common_or_generic_name_of_commodity": "commodity 9",
+                      "month_year_of_manufacture_packing_import": "year 9"
+                    }
+                  },
+                  {
+                    "id": "676a6260cac4860876a8e311",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:48:57.664Z"
+                    },
+                    "parent_item_id": "V10000000001",
+                    "descriptor": {
+                      "name": "Milk orange",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Milk orange short",
+                      "long_desc": "Milk orange long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e7_0"
+                      ],
+                      "code": "1:1000000000234"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "10"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "14"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "500.00",
+                      "maximum_value": "500.00"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 12",
+                      "additives_info": "additives info 12",
+                      "brand_owner_FSSAI_license_no": "fssai license 12",
+                      "other_FSSAI_license_no": "other license 12",
+                      "importer_FSSAI_license_no": "importer license 12"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 12",
+                      "manufacturer_or_packer_address": "address 12",
+                      "common_or_generic_name_of_commodity": "commodity 12",
+                      "month_year_of_manufacture_packing_import": "year 12"
+                    }
+                  },
+                  {
+                    "id": "676cf465e5eb3c28a8741e99",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:48:57.747Z"
+                    },
+                    "descriptor": {
+                      "name": "Pista milk",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Pista milk short",
+                      "long_desc": "Pista milk long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd72c_0"
+                      ],
+                      "code": "1:1000000000240"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "32"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "18.50",
+                      "maximum_value": "20.00"
+                    },
+                    "category_id": "Energy and Soft Drinks",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 18",
+                      "additives_info": "additives info 18",
+                      "brand_owner_FSSAI_license_no": "fssai license 18",
+                      "other_FSSAI_license_no": "other license 18",
+                      "importer_FSSAI_license_no": "importer license 18"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 18",
+                      "manufacturer_or_packer_address": "address 18",
+                      "common_or_generic_name_of_commodity": "commodity 18",
+                      "month_year_of_manufacture_packing_import": "year 18"
+                    }
+                  },
+                  {
+                    "id": "676cf465e5eb3c28a8741e9a",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:48:57.763Z"
+                    },
+                    "descriptor": {
+                      "name": "Mango milk",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Mango milk short",
+                      "long_desc": "Mango milk long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd72e_0"
+                      ],
+                      "code": "1:1000000000241"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "33"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "20.16",
+                      "maximum_value": "21.80"
+                    },
+                    "category_id": "Energy and Soft Drinks",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 7",
+                      "additives_info": "additives info 7",
+                      "brand_owner_FSSAI_license_no": "fssai license 7",
+                      "other_FSSAI_license_no": "other license 7",
+                      "importer_FSSAI_license_no": "importer license 7"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 7",
+                      "manufacturer_or_packer_address": "address 7",
+                      "common_or_generic_name_of_commodity": "commodity 7",
+                      "month_year_of_manufacture_packing_import": "year 7"
+                    }
+                  },
+                  {
+                    "id": "676cf465e5eb3c28a8741e9b",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:48:57.780Z"
+                    },
+                    "descriptor": {
+                      "name": "Vanilla milk",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Vanilla milk short",
+                      "long_desc": "Vanilla milk long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd730_0"
+                      ],
+                      "code": "1:1000000000242"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "35"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "18.51",
+                      "maximum_value": "20.01"
+                    },
+                    "category_id": "Energy and Soft Drinks",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 19",
+                      "additives_info": "additives info 19",
+                      "brand_owner_FSSAI_license_no": "fssai license 19",
+                      "other_FSSAI_license_no": "other license 19",
+                      "importer_FSSAI_license_no": "importer license 19"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer name 19",
+                      "manufacturer_or_packer_address": "packer address 19",
+                      "common_or_generic_name_of_commodity": "generic name 19",
+                      "month_year_of_manufacture_packing_import": "month year 19"
+                    }
+                  },
+                  {
+                    "id": "676a5f87cac4860876a8e2ff",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:48:57.793Z"
+                    },
+                    "descriptor": {
+                      "name": "Butter",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Butter short",
+                      "long_desc": "Butter long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd736_0"
+                      ],
+                      "code": "1:1000000000245"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "gram",
+                          "value": "200"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "23"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "109.38",
+                      "maximum_value": "124.30"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 3",
+                      "additives_info": "additives info 3",
+                      "brand_owner_FSSAI_license_no": "fssai license 3",
+                      "other_FSSAI_license_no": "other license 3",
+                      "importer_FSSAI_license_no": "importer license 3"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 13",
+                      "manufacturer_or_packer_address": "address 13",
+                      "common_or_generic_name_of_commodity": "commodity 13",
+                      "month_year_of_manufacture_packing_import": "year 13"
+                    }
+                  },
+                  {
+                    "id": "676a5f11cac4860876a8e2fb",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:48:57.810Z"
+                    },
+                    "descriptor": {
+                      "name": "Burfi",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Burfi short",
+                      "long_desc": "Burfi long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd73a_0"
+                      ],
+                      "code": "1:1000000000247"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "gram",
+                          "value": "200"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "22"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "71.20",
+                      "maximum_value": "80.00"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 2",
+                      "additives_info": "additives info 2",
+                      "brand_owner_FSSAI_license_no": "fssai license 2",
+                      "other_FSSAI_license_no": "other license 2",
+                      "importer_FSSAI_license_no": "importer license 2"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer name 2",
+                      "manufacturer_or_packer_address": "packer address 2",
+                      "common_or_generic_name_of_commodity": "commodity 2",
+                      "month_year_of_manufacture_packing_import": "packing import 2"
+                    }
+                  },
+                  {
+                    "id": "676aab3800d7d9212e3ba074",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:48:57.825Z"
+                    },
+                    "descriptor": {
+                      "name": "Watermelon",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Watermelon short",
+                      "long_desc": "Watermelon long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd740_0"
+                      ],
+                      "code": "1:2000000000349"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "kilogram",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "46"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "45.00",
+                      "maximum_value": "45.00"
+                    },
+                    "category_id": "Fruits and Vegetables",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M"
+                  },
+                  {
+                    "id": "676a9e1d00d7d9212e3b8f7f",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:48:57.837Z"
+                    },
+                    "descriptor": {
+                      "name": "Apple",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Apple short",
+                      "long_desc": "Apple long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd742_0"
+                      ],
+                      "code": "1:2000000000341"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "kilogram",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "21"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.02",
+                      "maximum_value": "120.02"
+                    },
+                    "category_id": "Fruits and Vegetables",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M"
+                  },
+                  {
+                    "id": "676aaa5700d7d9212e3ba019",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:48:57.849Z"
+                    },
+                    "descriptor": {
+                      "name": "Papaya",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Papaya short",
+                      "long_desc": "Papaya long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd746_0"
+                      ],
+                      "code": "1:2000000000346"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "kilogram",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "29"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "61.28",
+                      "maximum_value": "64.50"
+                    },
+                    "category_id": "Fruits and Vegetables",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M"
+                  },
+                  {
+                    "id": "676a9fa200d7d9212e3b8fbd",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:48:57.863Z"
+                    },
+                    "descriptor": {
+                      "name": "Beetroot",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Beetroot short",
+                      "long_desc": "Beetroot long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6762dbb841c7aa7c86d1d1c2_0"
+                      ],
+                      "code": "1:2000000000343"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "kilogram",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "0"
+                      },
+                      "maximum": {
+                        "count": "6"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "30.00",
+                      "maximum_value": "30.00"
+                    },
+                    "category_id": "Fruits and Vegetables",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M"
+                  },
+                  {
+                    "id": "676a9f7800d7d9212e3b8fbb",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:48:57.876Z"
+                    },
+                    "descriptor": {
+                      "name": "Beans haricot",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Beans haricot short",
+                      "long_desc": "Beans haricot long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6762dbb841c7aa7c86d1d1c4_0"
+                      ],
+                      "code": "1:2000000000342"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "kilogram",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "0"
+                      },
+                      "maximum": {
+                        "count": "5"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "76.42",
+                      "maximum_value": "78.38"
+                    },
+                    "category_id": "Fruits and Vegetables",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M"
+                  },
+                  {
+                    "id": "676a6126cac4860876a8e309",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:48:57.962Z"
+                    },
+                    "parent_item_id": "V10000000002",
+                    "descriptor": {
+                      "name": "Milk blue",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Milk blue short",
+                      "long_desc": "Milk blue long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e1_0"
+                      ],
+                      "code": "1:1000000000231"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "11"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00",
+                      "maximum_value": "40.00"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 8",
+                      "additives_info": "additives info 8",
+                      "brand_owner_FSSAI_license_no": "fssai license 8",
+                      "other_FSSAI_license_no": "other license 8",
+                      "importer_FSSAI_license_no": "importer license 8"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 8",
+                      "manufacturer_or_packer_address": "address 8",
+                      "common_or_generic_name_of_commodity": "commodity 8",
+                      "month_year_of_manufacture_packing_import": "year 8"
+                    }
+                  }
+                ],
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:48:57.359Z",
+                      "days": "1,2,3,4,5,6,7",
+                      "schedule": {
+                        "holidays": []
+                      },
+                      "range": {
+                        "start": "0001",
+                        "end": "2359"
+                      }
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "locality": "Bengaluru",
+                      "street": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "city": "Bengaluru",
+                      "area_code": "560103",
+                      "state": "KA"
+                    },
+                    "circle": {
+                      "gps": "12.9263841,77.6654374",
+                      "radius": {
+                        "unit": "km",
+                        "value": "999"
+                      }
+                    }
+                  }
+                ],
+                "categories": [
+                  {
+                    "id": "V10000000001",
+                    "descriptor": {
+                      "name": "Variant Group 10000000001"
+                    },
+                    "tags": [
+                      {
+                        "code": "type",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "variant_group"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "attr",
+                        "list": [
+                          {
+                            "code": "name",
+                            "value": "item.quantity.unitized.measure"
+                          },
+                          {
+                            "code": "seq",
+                            "value": "1"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "V10000000002",
+                    "descriptor": {
+                      "name": "Variant Group 10000000002"
+                    },
+                    "tags": [
+                      {
+                        "code": "type",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "variant_group"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "attr",
+                        "list": [
+                          {
+                            "code": "name",
+                            "value": "item.quantity.unitized.measure"
+                          },
+                          {
+                            "code": "seq",
+                            "value": "1"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_select.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_select.json
@@ -1,0 +1,1790 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_select",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "3e91f782-7627-4849-8b5e-a745943b2fec",
+          "timestamp": "2025-04-24T17:49:29.643Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "id": "676a6179cac4860876a8e30b",
+                "quantity": {
+                  "count": 2
+                }
+              },
+              {
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "id": "676a6126cac4860876a8e309",
+                "quantity": {
+                  "count": 3
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "680a79a248665475e6bf8c64~I1~1~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Ecom Express Limited",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P5D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a79a248665475e6bf8c67~P1~I1~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Bharat Mart",
+                "tracking": false,
+                "@ondc/org/category": "Immediate Delivery",
+                "@ondc/org/TAT": "PT60M",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a79a348665475e6bf8c69~MOVERDELIVERY~I1~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Mover",
+                "tracking": false,
+                "@ondc/org/category": "Immediate Delivery",
+                "@ondc/org/TAT": "PT30M",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a79a348665475e6bf8c6b~Delhivery~55993af7-96f7-4dce-ac13-4c9132acf5af~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Delhivery",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P4D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a79a348665475e6bf8c6c~P1~I1~I1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Exeed Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P8D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Immediate Delivery",
+                "@ondc/org/TAT": "PT60M",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~9e41392a-f17e-449b-9fd3-6661a494f707",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Express Delivery",
+                "@ondc/org/TAT": "P1D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Next Day Delivery",
+                "@ondc/org/TAT": "P1D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~0e71103f-54f5-4c36-99de-85b6d2166863",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Same Day Delivery",
+                "@ondc/org/TAT": "PT4H",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate~ns_immediate_f1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "NS_LSP",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "PT55M",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "NS_LSP",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "PT55M",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a79a348665475e6bf8c70~19537~YAARI-19537-20250424-AI6VUITR7J~SY-1745516963204-764",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Ecom Express",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a79a448665475e6bf8c71~DTDC~B2C SMART EXPRESS~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "DTDC",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P4D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "128335.18"
+              },
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "quantity": {
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "12"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "quantity": {
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "11"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a248665475e6bf8c64~I1~1~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "69"
+                  },
+                  "lsp_provider_id": "I1",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "1",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "name": "Standard Delivery",
+                      "code": "P2H2P",
+                      "short_desc": "Fast Delivery For Items",
+                      "long_desc": "Fast Delivery for Items"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "1",
+                    "price": {
+                      "currency": "INR",
+                      "value": "69"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "timestamp": "2025-04-28",
+                      "duration": "P5D"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a248665475e6bf8c67~P1~I1~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "59.00"
+                  },
+                  "lsp_provider_id": "P1",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "I1",
+                    "parent_item_id": "",
+                    "category_id": "Immediate Delivery",
+                    "fulfillment_id": "1",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "60 min delivery",
+                      "short_desc": "60 min delivery for F&B",
+                      "long_desc": "60 min delivery for F&B"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "59.00"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2023-06-06"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c69~MOVERDELIVERY~I1~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "25527"
+                  },
+                  "lsp_provider_id": "MOVERDELIVERY",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "I1",
+                    "parent_item_id": "",
+                    "category_id": "Immediate Delivery",
+                    "fulfillment_id": "1",
+                    "descriptor": {
+                      "name": "30 min delivery",
+                      "short_desc": "30 min delivery for F&B",
+                      "long_desc": "30 min delivery for F&B",
+                      "code": "P2P"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "25527"
+                    },
+                    "time": {
+                      "duration": "PT30M",
+                      "label": "TAT",
+                      "timestamp": "2025-04-24T17:49:22.7616047Z"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6b~Delhivery~55993af7-96f7-4dce-ac13-4c9132acf5af~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "7500.72"
+                  },
+                  "lsp_provider_id": "Delhivery",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "55993af7-96f7-4dce-ac13-4c9132acf5af",
+                    "parent_item_id": "",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "1",
+                    "descriptor": {
+                      "code": "P2H2P",
+                      "name": "Standard Delivery",
+                      "short_desc": "Delhivery Surface",
+                      "long_desc": "Delhivery Surface"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "7500.72"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P4D",
+                      "timestamp": "2025-04-28"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6c~P1~I1~I1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "65560.00"
+                  },
+                  "lsp_provider_id": "P1",
+                  "lsp_fulfillment_id": "I1",
+                  "lsp_item_details": {
+                    "id": "I1",
+                    "parent_item_id": "",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "I1",
+                    "descriptor": {
+                      "code": "P2H2P",
+                      "name": "Standard",
+                      "short_desc": "Standard",
+                      "long_desc": "Standard"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "65560.00"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P8D",
+                      "timestamp": "2025-04-24T17:49:23.026281Z"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                  "lsp_item_details": {
+                    "id": "imd_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Immediate Delivery",
+                      "long_desc": "Upto 60 mins for Delivery",
+                      "short_desc": "Upto 60 mins for Delivery"
+                    },
+                    "category_id": "Immediate Delivery",
+                    "fulfillment_id": "9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~9e41392a-f17e-449b-9fd3-6661a494f707",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "9e41392a-f17e-449b-9fd3-6661a494f707",
+                  "lsp_item_details": {
+                    "id": "exp_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Express Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Express Delivery",
+                    "fulfillment_id": "9e41392a-f17e-449b-9fd3-6661a494f707",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                  "lsp_item_details": {
+                    "id": "nex_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Next Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Next Day Delivery",
+                    "fulfillment_id": "aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~0e71103f-54f5-4c36-99de-85b6d2166863",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "0e71103f-54f5-4c36-99de-85b6d2166863",
+                  "lsp_item_details": {
+                    "id": "same_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Same Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Same Day Delivery",
+                    "fulfillment_id": "0e71103f-54f5-4c36-99de-85b6d2166863",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT4H",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "2.0"
+                  },
+                  "lsp_provider_id": "NS_LSP",
+                  "lsp_fulfillment_id": "ns_immediate_f1",
+                  "lsp_item_details": {
+                    "id": "ns_immediate",
+                    "parent_item_id": "",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "ns_immediate_f1",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "NS LSP Immediate Delivery",
+                      "short_desc": "Immediate Delivery by NS LSP",
+                      "long_desc": "Immediate Delivery by NS LSP"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2.0"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT55M",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  },
+                  "lsp_provider_id": "NS_LSP",
+                  "lsp_fulfillment_id": "ns_immediate_f1-RTO",
+                  "lsp_item_details": {
+                    "id": "ns_immediate-RTO",
+                    "parent_item_id": "ns_immediate",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "ns_immediate_f1-RTO",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "RTO quote",
+                      "short_desc": "RTO quote",
+                      "long_desc": "RTO quote"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT55M",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c70~19537~YAARI-19537-20250424-AI6VUITR7J~SY-1745516963204-764",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "395.74"
+                  },
+                  "lsp_provider_id": "19537",
+                  "lsp_fulfillment_id": "SY-1745516963204-764",
+                  "lsp_item_details": {
+                    "id": "YAARI-19537-20250424-AI6VUITR7J",
+                    "parent_item_id": "",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "SY-1745516963204-764",
+                    "descriptor": {
+                      "code": "P2H2P",
+                      "name": "Ecom Express",
+                      "short_desc": "Ecom Express",
+                      "long_desc": "Ecom Express"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "395.74"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a448665475e6bf8c71~DTDC~B2C SMART EXPRESS~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "815.00"
+                  },
+                  "lsp_provider_id": "DTDC",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "B2C SMART EXPRESS",
+                    "category_id": "Standard Delivery",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2H2P",
+                      "name": "Standard Delivery",
+                      "short_desc": "B2C SMART EXPRESS",
+                      "long_desc": "3 - 4 Day/s"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "815.00"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P4D",
+                      "timestamp": "2025-04-28"
+                    },
+                    "fulfillment_id": "1"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a248665475e6bf8c64~I1~1~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a248665475e6bf8c64~I1~1~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a248665475e6bf8c64~I1~1~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a248665475e6bf8c67~P1~I1~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a248665475e6bf8c67~P1~I1~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a248665475e6bf8c67~P1~I1~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c69~MOVERDELIVERY~I1~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c69~MOVERDELIVERY~I1~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c69~MOVERDELIVERY~I1~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6b~Delhivery~55993af7-96f7-4dce-ac13-4c9132acf5af~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6b~Delhivery~55993af7-96f7-4dce-ac13-4c9132acf5af~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6b~Delhivery~55993af7-96f7-4dce-ac13-4c9132acf5af~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6c~P1~I1~I1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6c~P1~I1~I1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6c~P1~I1~I1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~9a0e7e5a-da21-48b0-8d94-a0d69e82d812",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~9e41392a-f17e-449b-9fd3-6661a494f707",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~9e41392a-f17e-449b-9fd3-6661a494f707",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~9e41392a-f17e-449b-9fd3-6661a494f707",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~aa6ac78d-3cae-49d5-8bcf-b89dcdb2485f",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~0e71103f-54f5-4c36-99de-85b6d2166863",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~0e71103f-54f5-4c36-99de-85b6d2166863",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~0e71103f-54f5-4c36-99de-85b6d2166863",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6f~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c70~19537~YAARI-19537-20250424-AI6VUITR7J~SY-1745516963204-764",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c70~19537~YAARI-19537-20250424-AI6VUITR7J~SY-1745516963204-764",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c70~19537~YAARI-19537-20250424-AI6VUITR7J~SY-1745516963204-764",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a448665475e6bf8c71~DTDC~B2C SMART EXPRESS~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a448665475e6bf8c71~DTDC~B2C SMART EXPRESS~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a448665475e6bf8c71~DTDC~B2C SMART EXPRESS~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "ttl": "P1D"
+            },
+            "tags": [
+              {
+                "code": "bpp_terms",
+                "list": [
+                  {
+                    "code": "accept_bap_terms",
+                    "value": "Y"
+                  },
+                  {
+                    "code": "np_type",
+                    "value": "MSN"
+                  },
+                  {
+                    "code": "collect_payment",
+                    "value": "Y"
+                  },
+                  {
+                    "code": "max_liability",
+                    "value": "2"
+                  },
+                  {
+                    "code": "max_liability_cap",
+                    "value": "10000"
+                  },
+                  {
+                    "code": "mandatory_arbitration",
+                    "value": "false"
+                  },
+                  {
+                    "code": "court_jurisdiction",
+                    "value": "Bengaluru"
+                  },
+                  {
+                    "code": "delay_interest",
+                    "value": "7"
+                  },
+                  {
+                    "code": "tax_number",
+                    "value": "29ABGCS7802J1ZX"
+                  },
+                  {
+                    "code": "provider_tax_number",
+                    "value": "ABGCS7802J"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_1_accepted.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_1_accepted.json
@@ -1,0 +1,312 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "11e900c1-c7c0-43e0-a398-3cfd16031920",
+          "timestamp": "2025-04-24T17:55:24.412Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "Accepted",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D",
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": "other pickup confirmation code",
+                    "long_desc": "Pls pickup orders from counter number 01."
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T17:30:00.000Z",
+                      "end": "2025-04-24T19:30:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "instructions": {
+                    "name": "Proof of delivery",
+                    "code": "3",
+                    "short_desc": "no delivery code",
+                    "long_desc": ""
+                  },
+                  "time": {
+                    "range": {
+                      "end": "2025-04-24T17:56:43.270Z"
+                    }
+                  }
+                },
+                "state": {
+                  "descriptor": {
+                    "code": "Pending",
+                    "name": "Getting ready for shipment (packaging)"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:55:24.351Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_2_packed.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_2_packed.json
@@ -1,0 +1,294 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "d7539474-cba5-43d1-8dcb-3b95d482863e",
+          "timestamp": "2025-04-24T17:55:34.406Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Packed",
+                    "name": "Packaging completed. Ready to ship"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:55:24.351Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_3_agent_assigned.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_3_agent_assigned.json
@@ -1,0 +1,302 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "a0b3d4d5-6983-4d51-b3fe-9ac289a9361c",
+          "timestamp": "2025-04-24T17:55:42.931Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Agent-assigned",
+                    "name": "Agent assigned"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:55:24.351Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_4_picked_up.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_4_picked_up.json
@@ -1,0 +1,309 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "99f1e53c-ade7-4dd9-991e-cd6423698143",
+          "timestamp": "2025-04-24T17:55:57.659Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-picked-up",
+                    "name": "Product picked up from the source and shipment started"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:55:57.504Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:55:24.351Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_5_out_for_delivery.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_5_out_for_delivery.json
@@ -1,0 +1,309 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "03bfe26a-b46a-4b86-b363-05303b8f4c9c",
+          "timestamp": "2025-04-24T17:56:03.689Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Out-for-delivery",
+                    "name": "Product would be delivered soon"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:55:57.504Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:55:24.351Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_6_response.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_6_response.json
@@ -1,0 +1,309 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "2c330ebb-7daa-453c-9485-9fa142390b08",
+          "timestamp": "2025-04-24T17:56:19.232Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Out-for-delivery",
+                    "name": "Product would be delivered soon"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:55:57.504Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:55:24.351Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_7_rto_delivered.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_7_rto_delivered.json
@@ -1,0 +1,488 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "c2c711a3-d6ae-4249-814e-965e81337b67",
+          "timestamp": "2025-04-24T17:57:11.917Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": "0"
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": "0"
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "fulfillment_id": "C1680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "quantity": {
+                  "count": "0"
+                }
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "fulfillment_id": "C1680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "quantity": {
+                  "count": "0"
+                }
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Cancelled",
+                    "name": "Product cancellation"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:55:57.504Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "precancel_state",
+                    "list": [
+                      {
+                        "code": "fulfillment_state",
+                        "value": "Out-for-delivery"
+                      },
+                      {
+                        "code": "updated_at",
+                        "value": "2025-04-24T17:56:03.540Z"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_event",
+                    "list": [
+                      {
+                        "code": "rto_id",
+                        "value": "968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                      },
+                      {
+                        "code": "cancellation_reason_id",
+                        "value": "016"
+                      },
+                      {
+                        "code": "cancelled_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                      },
+                      {
+                        "code": "retry_count",
+                        "value": "2"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "cancel_request",
+                    "list": [
+                      {
+                        "code": "retry_count",
+                        "value": "2"
+                      },
+                      {
+                        "code": "rto_id",
+                        "value": "RTO0968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                      },
+                      {
+                        "code": "reason_id",
+                        "value": ""
+                      },
+                      {
+                        "code": "initiated_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              },
+              {
+                "id": "RTO0968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                "type": "RTO",
+                "state": {
+                  "descriptor": {
+                    "code": "RTO-Delivered",
+                    "name": "The order delivered back to the source as the customer refused to accept the order"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T17:56:28.834Z",
+                      "end": "2025-04-24T17:56:28.834Z"
+                    },
+                    "timestamp": "2025-04-24T17:56:28.834Z"
+                  },
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "timestamp": "2025-04-24T17:57:11.747Z"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "7915.62"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "2612.06"
+                  },
+                  "@ondc/org/item_id": "rto_std",
+                  "@ondc/org/title_type": "rto"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "rto_std",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:55:24.351Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_8_response.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_on_status_8_response.json
@@ -1,0 +1,489 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "96adeb6c-a0d4-4695-a51a-0cf0b7567aed",
+          "timestamp": "2025-04-24T17:58:07.999Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517217464",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": "0"
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": "0"
+                },
+                "fulfillment_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657"
+              },
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "fulfillment_id": "C1680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "quantity": {
+                  "count": "0"
+                }
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "fulfillment_id": "C1680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "quantity": {
+                  "count": "0"
+                }
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T17:50:00.982Z",
+              "updated_at": "2025-04-24T17:50:00.982Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Cancelled",
+                    "name": "Product cancellation"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T17:55:57.504Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "precancel_state",
+                    "list": [
+                      {
+                        "code": "fulfillment_state",
+                        "value": "Out-for-delivery"
+                      },
+                      {
+                        "code": "updated_at",
+                        "value": "2025-04-24T17:56:03.540Z"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_event",
+                    "list": [
+                      {
+                        "code": "rto_id",
+                        "value": "968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                      },
+                      {
+                        "code": "cancellation_reason_id",
+                        "value": "016"
+                      },
+                      {
+                        "code": "cancelled_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                      },
+                      {
+                        "code": "retry_count",
+                        "value": "2"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "cancel_request",
+                    "list": [
+                      {
+                        "code": "retry_count",
+                        "value": "2"
+                      },
+                      {
+                        "code": "rto_id",
+                        "value": "RTO0968fc226-b8a2-45bf-85d6-29ef48a30b3f"
+                      },
+                      {
+                        "code": "reason_id",
+                        "value": ""
+                      },
+                      {
+                        "code": "initiated_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/seller"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              },
+              {
+                "id": "RTO0968fc226-b8a2-45bf-85d6-29ef48a30b3f",
+                "type": "RTO",
+                "state": {
+                  "descriptor": {
+                    "code": "RTO-Delivered",
+                    "name": "The order delivered back to the source as the customer refused to accept the order"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T17:56:28.834Z",
+                      "end": "2025-04-24T17:56:28.834Z"
+                    },
+                    "timestamp": "2025-04-24T17:56:28.834Z"
+                  },
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "timestamp": "2025-04-24T17:57:11.747Z"
+                  }
+                },
+                "tags": null
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "7915.62"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a79a348665475e6bf8c6d~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~c9b43760-36f5-4f9e-a9b9-4c08ed1c1657",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "2612.06"
+                  },
+                  "@ondc/org/item_id": "rto_std",
+                  "@ondc/org/title_type": "rto"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "rto_std",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "476105d7-c02f-4a79-a846-a7335c98177e"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:53:37.464Z",
+            "updated_at": "2025-04-24T17:55:24.351Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_search.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_search.json
@@ -1,0 +1,34 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "search",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "98e7e7ab-95f9-43fb-b8b8-7b5dc990820e",
+          "timestamp": "2025-04-24T17:48:53.899Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "intent": {
+            "payment": {
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3"
+            },
+            "tags": [
+              {
+                "code": "catalog_full",
+                "list": [
+                  {
+                    "code": "payload_type",
+                    "value": "inline"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_select.json
+++ b/Lekhha/Retail-Logistics/Flow_A2_RTO_Flow/Retail_select.json
@@ -1,0 +1,60 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "select",
+          "transaction_id": "f10b9e1b-db86-464f-aa5f-d6f77c25bf2b",
+          "message_id": "3e91f782-7627-4849-8b5e-a745943b2fec",
+          "timestamp": "2025-04-24T17:49:21.241Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "ttl": "PT30S",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                }
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              }
+            ],
+            "payment": {
+              "type": "ON-ORDER"
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A3_IGM/Downloaded_logs_Retail.json
+++ b/Lekhha/Retail-Logistics/Flow_A3_IGM/Downloaded_logs_Retail.json
@@ -1,0 +1,7598 @@
+{
+    "domain": "ONDC:RET10",
+    "payload": {
+      "search_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745516720\",expires=\"1745520320\",headers=\"(created) (expires) digest\",signature=\"sqKE7G9iqXyHJ5G7HP81avpJX862XqeOky8/8MbjtX8izCXedWjOH8Nulqh0KufqUqNnEaCt9exM/W0dfTgMBg==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "search",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "d61a2ea2-d544-4d90-a3db-85be2ca13675",
+            "timestamp": "2025-04-24T17:45:20.418Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "intent": {
+              "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3"
+              },
+              "tags": [
+                {
+                  "code": "catalog_full",
+                  "list": [
+                    {
+                      "code": "payload_type",
+                      "value": "inline"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "action": "search",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "d61a2ea2-d544-4d90-a3db-85be2ca13675",
+            "timestamp": "2025-04-24T17:45:20.532Z",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_search_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745516724\",expires=\"1745546724655\",headers=\"(created) (expires) digest\",signature=\"beuH6E7GeucnfCHgSrjFK/+ERQaoEup177UiudmU6EqJx7AMZtOQ48P70HveKOugustELCU4pptfCkxZbXLOAA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "d61a2ea2-d544-4d90-a3db-85be2ca13675",
+            "timestamp": "2025-04-24T17:45:24.651Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "catalog": {
+              "bpp/fulfillments": [
+                {
+                  "id": "1",
+                  "type": "Delivery",
+                  "contact": {
+                    "phone": "9900025784",
+                    "email": "sgupta.scm@gmail.com"
+                  }
+                }
+              ],
+              "bpp/descriptor": {
+                "name": "Lekhha",
+                "symbol": "https://lekhha.com/wp-content/uploads/2023/07/logo-light-1.png",
+                "short_desc": "App-based platform for order and inventory management.",
+                "long_desc": "LEKHHA is a simple solution to help you comprehensively run your business operations. Discover it to also track & manage your personal needs & resources. Reach out to us to serve you as your solution partner.",
+                "images": [
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/logo",
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/vendor",
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/consumer",
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/inventory"
+                ],
+                "tags": [
+                  {
+                    "code": "bpp_terms",
+                    "list": [
+                      {
+                        "code": "np_type",
+                        "value": "MSN"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "bpp/providers": [
+                {
+                  "id": "674ecb33d7b9e10f4210d972",
+                  "time": {
+                    "label": "enable",
+                    "timestamp": "2025-04-24T17:45:23.878Z"
+                  },
+                  "descriptor": {
+                    "name": "Lekhha Provider A",
+                    "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecb33d7b9e10f4210d972_S",
+                    "short_desc": "Lekhha_Seller_1 kyc short",
+                    "long_desc": "Lekhha_Seller_1 kyc long",
+                    "images": [
+                      "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecb33d7b9e10f4210d972"
+                    ]
+                  },
+                  "ttl": "P1D",
+                  "creds": [
+                    {
+                      "descriptor": {
+                        "code": "Lekhha_Seller_1_cred1",
+                        "name": "Lekhha_Seller_1 cred1",
+                        "short_desc": "Lekhha_Seller_1 cred1 short"
+                      },
+                      "id": "674ecbc6d7b9e10f4210d973_1",
+                      "tags": [
+                        {
+                          "code": "verification",
+                          "list": [
+                            {
+                              "code": "verify_url",
+                              "value": "https://url1url.com/verify1"
+                            },
+                            {
+                              "code": "valid_from",
+                              "value": "2024-12-09T00:00:00.000Z"
+                            },
+                            {
+                              "code": "valid_to",
+                              "value": "2027-03-31T00:00:00.000Z"
+                            }
+                          ]
+                        }
+                      ],
+                      "url": "https://url1url.com"
+                    }
+                  ],
+                  "fulfillments": [
+                    {
+                      "id": "1",
+                      "type": "Delivery",
+                      "contact": {
+                        "phone": "9900025784",
+                        "email": "sgupta.scm@gmail.com"
+                      }
+                    }
+                  ],
+                  "tags": [
+                    {
+                      "code": "order_value",
+                      "list": [
+                        {
+                          "code": "min_value",
+                          "value": "150.5"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "timing",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "Order"
+                        },
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "day_from",
+                          "value": "1"
+                        },
+                        {
+                          "code": "day_to",
+                          "value": "7"
+                        },
+                        {
+                          "code": "time_from",
+                          "value": "0001"
+                        },
+                        {
+                          "code": "time_to",
+                          "value": "2359"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "timing",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "Delivery"
+                        },
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "day_from",
+                          "value": "1"
+                        },
+                        {
+                          "code": "day_to",
+                          "value": "7"
+                        },
+                        {
+                          "code": "time_from",
+                          "value": "0001"
+                        },
+                        {
+                          "code": "time_to",
+                          "value": "2359"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "timing",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "Self-Pickup"
+                        },
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "day_from",
+                          "value": "1"
+                        },
+                        {
+                          "code": "day_to",
+                          "value": "7"
+                        },
+                        {
+                          "code": "time_from",
+                          "value": "0001"
+                        },
+                        {
+                          "code": "time_to",
+                          "value": "2359"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "serviceability",
+                      "list": [
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "category",
+                          "value": "Bakery, Cakes & Dairy"
+                        },
+                        {
+                          "code": "type",
+                          "value": "11"
+                        },
+                        {
+                          "code": "val",
+                          "value": "100000-999999"
+                        },
+                        {
+                          "code": "unit",
+                          "value": "pincode"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "serviceability",
+                      "list": [
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "category",
+                          "value": "Energy and Soft Drinks"
+                        },
+                        {
+                          "code": "type",
+                          "value": "11"
+                        },
+                        {
+                          "code": "val",
+                          "value": "100000-999999"
+                        },
+                        {
+                          "code": "unit",
+                          "value": "pincode"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "serviceability",
+                      "list": [
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "category",
+                          "value": "Fruits and Vegetables"
+                        },
+                        {
+                          "code": "type",
+                          "value": "11"
+                        },
+                        {
+                          "code": "val",
+                          "value": "100000-999999"
+                        },
+                        {
+                          "code": "unit",
+                          "value": "pincode"
+                        }
+                      ]
+                    }
+                  ],
+                  "items": [
+                    {
+                      "id": "676a61f6cac4860876a8e30f",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.155Z"
+                      },
+                      "parent_item_id": "V10000000001",
+                      "descriptor": {
+                        "name": "Milk orange",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk orange short",
+                        "long_desc": "Milk orange long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e3_0"
+                        ],
+                        "code": "1:1000000000232"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "13"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "49.82",
+                        "maximum_value": "53.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 11",
+                        "additives_info": "additives info 11",
+                        "brand_owner_FSSAI_license_no": "fssai license 11",
+                        "other_FSSAI_license_no": "other license 11",
+                        "importer_FSSAI_license_no": "importer license 11"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 11",
+                        "manufacturer_or_packer_address": "address 11",
+                        "common_or_generic_name_of_commodity": "commodity 11",
+                        "month_year_of_manufacture_packing_import": "year 11"
+                      }
+                    },
+                    {
+                      "id": "676a6179cac4860876a8e30b",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.185Z"
+                      },
+                      "parent_item_id": "V10000000002",
+                      "descriptor": {
+                        "name": "Milk blue",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk blue short",
+                        "long_desc": "Milk blue long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e5_0"
+                        ],
+                        "code": "1:1000000000233"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "10"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "12"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "380.00",
+                        "maximum_value": "400.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 9",
+                        "additives_info": "additives info 9",
+                        "brand_owner_FSSAI_license_no": "fssai license 9",
+                        "other_FSSAI_license_no": "other license 9",
+                        "importer_FSSAI_license_no": "importer license 9"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 9",
+                        "manufacturer_or_packer_address": "address 9",
+                        "common_or_generic_name_of_commodity": "commodity 9",
+                        "month_year_of_manufacture_packing_import": "year 9"
+                      }
+                    },
+                    {
+                      "id": "676a6260cac4860876a8e311",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.217Z"
+                      },
+                      "parent_item_id": "V10000000001",
+                      "descriptor": {
+                        "name": "Milk orange",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk orange short",
+                        "long_desc": "Milk orange long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e7_0"
+                        ],
+                        "code": "1:1000000000234"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "10"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "14"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "500.00",
+                        "maximum_value": "500.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 12",
+                        "additives_info": "additives info 12",
+                        "brand_owner_FSSAI_license_no": "fssai license 12",
+                        "other_FSSAI_license_no": "other license 12",
+                        "importer_FSSAI_license_no": "importer license 12"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 12",
+                        "manufacturer_or_packer_address": "address 12",
+                        "common_or_generic_name_of_commodity": "commodity 12",
+                        "month_year_of_manufacture_packing_import": "year 12"
+                      }
+                    },
+                    {
+                      "id": "676cf465e5eb3c28a8741e99",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.313Z"
+                      },
+                      "descriptor": {
+                        "name": "Pista milk",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Pista milk short",
+                        "long_desc": "Pista milk long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd72c_0"
+                        ],
+                        "code": "1:1000000000240"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "32"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "18.50",
+                        "maximum_value": "20.00"
+                      },
+                      "category_id": "Energy and Soft Drinks",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 18",
+                        "additives_info": "additives info 18",
+                        "brand_owner_FSSAI_license_no": "fssai license 18",
+                        "other_FSSAI_license_no": "other license 18",
+                        "importer_FSSAI_license_no": "importer license 18"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 18",
+                        "manufacturer_or_packer_address": "address 18",
+                        "common_or_generic_name_of_commodity": "commodity 18",
+                        "month_year_of_manufacture_packing_import": "year 18"
+                      }
+                    },
+                    {
+                      "id": "676cf465e5eb3c28a8741e9a",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.332Z"
+                      },
+                      "descriptor": {
+                        "name": "Mango milk",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Mango milk short",
+                        "long_desc": "Mango milk long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd72e_0"
+                        ],
+                        "code": "1:1000000000241"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "33"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "20.16",
+                        "maximum_value": "21.80"
+                      },
+                      "category_id": "Energy and Soft Drinks",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 7",
+                        "additives_info": "additives info 7",
+                        "brand_owner_FSSAI_license_no": "fssai license 7",
+                        "other_FSSAI_license_no": "other license 7",
+                        "importer_FSSAI_license_no": "importer license 7"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 7",
+                        "manufacturer_or_packer_address": "address 7",
+                        "common_or_generic_name_of_commodity": "commodity 7",
+                        "month_year_of_manufacture_packing_import": "year 7"
+                      }
+                    },
+                    {
+                      "id": "676cf465e5eb3c28a8741e9b",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.349Z"
+                      },
+                      "descriptor": {
+                        "name": "Vanilla milk",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Vanilla milk short",
+                        "long_desc": "Vanilla milk long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd730_0"
+                        ],
+                        "code": "1:1000000000242"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "35"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "18.51",
+                        "maximum_value": "20.01"
+                      },
+                      "category_id": "Energy and Soft Drinks",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 19",
+                        "additives_info": "additives info 19",
+                        "brand_owner_FSSAI_license_no": "fssai license 19",
+                        "other_FSSAI_license_no": "other license 19",
+                        "importer_FSSAI_license_no": "importer license 19"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer name 19",
+                        "manufacturer_or_packer_address": "packer address 19",
+                        "common_or_generic_name_of_commodity": "generic name 19",
+                        "month_year_of_manufacture_packing_import": "month year 19"
+                      }
+                    },
+                    {
+                      "id": "676a5f87cac4860876a8e2ff",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.362Z"
+                      },
+                      "descriptor": {
+                        "name": "Butter",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Butter short",
+                        "long_desc": "Butter long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd736_0"
+                        ],
+                        "code": "1:1000000000245"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "gram",
+                            "value": "200"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "23"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "109.38",
+                        "maximum_value": "124.30"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 3",
+                        "additives_info": "additives info 3",
+                        "brand_owner_FSSAI_license_no": "fssai license 3",
+                        "other_FSSAI_license_no": "other license 3",
+                        "importer_FSSAI_license_no": "importer license 3"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 13",
+                        "manufacturer_or_packer_address": "address 13",
+                        "common_or_generic_name_of_commodity": "commodity 13",
+                        "month_year_of_manufacture_packing_import": "year 13"
+                      }
+                    },
+                    {
+                      "id": "676a5f11cac4860876a8e2fb",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.373Z"
+                      },
+                      "descriptor": {
+                        "name": "Burfi",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Burfi short",
+                        "long_desc": "Burfi long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd73a_0"
+                        ],
+                        "code": "1:1000000000247"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "gram",
+                            "value": "200"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "22"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "71.20",
+                        "maximum_value": "80.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 2",
+                        "additives_info": "additives info 2",
+                        "brand_owner_FSSAI_license_no": "fssai license 2",
+                        "other_FSSAI_license_no": "other license 2",
+                        "importer_FSSAI_license_no": "importer license 2"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer name 2",
+                        "manufacturer_or_packer_address": "packer address 2",
+                        "common_or_generic_name_of_commodity": "commodity 2",
+                        "month_year_of_manufacture_packing_import": "packing import 2"
+                      }
+                    },
+                    {
+                      "id": "676aab3800d7d9212e3ba074",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.386Z"
+                      },
+                      "descriptor": {
+                        "name": "Watermelon",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Watermelon short",
+                        "long_desc": "Watermelon long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd740_0"
+                        ],
+                        "code": "1:2000000000349"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "46"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "45.00",
+                        "maximum_value": "45.00"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a9e1d00d7d9212e3b8f7f",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.401Z"
+                      },
+                      "descriptor": {
+                        "name": "Apple",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Apple short",
+                        "long_desc": "Apple long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd742_0"
+                        ],
+                        "code": "1:2000000000341"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "21"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "120.02",
+                        "maximum_value": "120.02"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676aaa5700d7d9212e3ba019",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.412Z"
+                      },
+                      "descriptor": {
+                        "name": "Papaya",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Papaya short",
+                        "long_desc": "Papaya long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd746_0"
+                        ],
+                        "code": "1:2000000000346"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "29"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "61.28",
+                        "maximum_value": "64.50"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a9fa200d7d9212e3b8fbd",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.427Z"
+                      },
+                      "descriptor": {
+                        "name": "Beetroot",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Beetroot short",
+                        "long_desc": "Beetroot long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6762dbb841c7aa7c86d1d1c2_0"
+                        ],
+                        "code": "1:2000000000343"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "0"
+                        },
+                        "maximum": {
+                          "count": "6"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "30.00",
+                        "maximum_value": "30.00"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a9f7800d7d9212e3b8fbb",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.438Z"
+                      },
+                      "descriptor": {
+                        "name": "Beans haricot",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Beans haricot short",
+                        "long_desc": "Beans haricot long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6762dbb841c7aa7c86d1d1c4_0"
+                        ],
+                        "code": "1:2000000000342"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "0"
+                        },
+                        "maximum": {
+                          "count": "5"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "76.42",
+                        "maximum_value": "78.38"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a6126cac4860876a8e309",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:24.519Z"
+                      },
+                      "parent_item_id": "V10000000002",
+                      "descriptor": {
+                        "name": "Milk blue",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk blue short",
+                        "long_desc": "Milk blue long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e1_0"
+                        ],
+                        "code": "1:1000000000231"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "11"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00",
+                        "maximum_value": "40.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 8",
+                        "additives_info": "additives info 8",
+                        "brand_owner_FSSAI_license_no": "fssai license 8",
+                        "other_FSSAI_license_no": "other license 8",
+                        "importer_FSSAI_license_no": "importer license 8"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 8",
+                        "manufacturer_or_packer_address": "address 8",
+                        "common_or_generic_name_of_commodity": "commodity 8",
+                        "month_year_of_manufacture_packing_import": "year 8"
+                      }
+                    }
+                  ],
+                  "locations": [
+                    {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:45:23.899Z",
+                        "days": "1,2,3,4,5,6,7",
+                        "schedule": {
+                          "holidays": []
+                        },
+                        "range": {
+                          "start": "0001",
+                          "end": "2359"
+                        }
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "locality": "Bengaluru",
+                        "street": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "city": "Bengaluru",
+                        "area_code": "560103",
+                        "state": "KA"
+                      },
+                      "circle": {
+                        "gps": "12.9263841,77.6654374",
+                        "radius": {
+                          "unit": "km",
+                          "value": "999"
+                        }
+                      }
+                    }
+                  ],
+                  "categories": [
+                    {
+                      "id": "V10000000001",
+                      "descriptor": {
+                        "name": "Variant Group 10000000001"
+                      },
+                      "tags": [
+                        {
+                          "code": "type",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "variant_group"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "attr",
+                          "list": [
+                            {
+                              "code": "name",
+                              "value": "item.quantity.unitized.measure"
+                            },
+                            {
+                              "code": "seq",
+                              "value": "1"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "V10000000002",
+                      "descriptor": {
+                        "name": "Variant Group 10000000002"
+                      },
+                      "tags": [
+                        {
+                          "code": "type",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "variant_group"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "attr",
+                          "list": [
+                            {
+                              "code": "name",
+                              "value": "item.quantity.unitized.measure"
+                            },
+                            {
+                              "code": "seq",
+                              "value": "1"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "d61a2ea2-d544-4d90-a3db-85be2ca13675",
+            "timestamp": "2025-04-24T17:45:24.651Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            },
+            "tags": [
+              {
+                "code": "CATALOG_PROCESSING",
+                "list": [
+                  {
+                    "code": "MIN_PROCESS_DURATION",
+                    "value": "PT1S"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "select_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745516796\",expires=\"1745520396\",headers=\"(created) (expires) digest\",signature=\"1JOl0aWn1cf6hkbhP8cSMpefgY0cu60a6AwKKRalQPr+9pAC+FATR061sV0eCsURYV80a5DSq1FPlc+7eyhWBA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "select",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "40b6f53d-ac0d-4739-ac1d-2408a3445482",
+            "timestamp": "2025-04-24T17:46:36.533Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  }
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                }
+              ],
+              "payment": {
+                "type": "ON-ORDER"
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "select",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "40b6f53d-ac0d-4739-ac1d-2408a3445482",
+            "timestamp": "2025-04-24T17:46:36.805Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_select_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745516805\",expires=\"1745546805096\",headers=\"(created) (expires) digest\",signature=\"famnM13/57LUMLNm/9jsx8nePoQlW0EsF8yjdSDscggvvjdEheR/ZHl8+h7nW2rdST+Dfwojk2VvjgIwJiYmDQ==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_select",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "40b6f53d-ac0d-4739-ac1d-2408a3445482",
+            "timestamp": "2025-04-24T17:46:45.092Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "id": "676a6179cac4860876a8e30b",
+                  "quantity": {
+                    "count": 2
+                  }
+                },
+                {
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "id": "676a6126cac4860876a8e309",
+                  "quantity": {
+                    "count": 3
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c27~I1~1~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Ecom Express Limited",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P5D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c28~19537~YAARI-19537-20250424-U2JJE6IXS4~SY-1745516797923-51",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Ecom Express",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "NS_LSP",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "PT55M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "NS_LSP",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "PT55M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Immediate Delivery",
+                  "@ondc/org/TAT": "PT60M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~a60ad63c-b760-42be-98e0-6022237da726",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Express Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Next Day Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Same Day Delivery",
+                  "@ondc/org/TAT": "PT4H",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c2b~Delhivery~3204dd9f-423a-46a7-8b94-f11642a83977~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Delhivery",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P4D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78fe48665475e6bf8c2c~P1~I1~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Bharat Mart",
+                  "tracking": false,
+                  "@ondc/org/category": "Immediate Delivery",
+                  "@ondc/org/TAT": "PT60M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78ff48665475e6bf8c2f~MOVERDELIVERY~I1~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Mover",
+                  "tracking": false,
+                  "@ondc/org/category": "Immediate Delivery",
+                  "@ondc/org/TAT": "PT30M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a78ff48665475e6bf8c30~Bluedart Express~BDEEP0~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Bluedart Express",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P4D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a790048665475e6bf8c31~DTDC~B2C SMART EXPRESS~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "DTDC",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P4D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a790048665475e6bf8c32~P1~I1~I1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Exeed Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P8D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "129831.05"
+                },
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "quantity": {
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "12"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "quantity": {
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "11"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c27~I1~1~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "69"
+                    },
+                    "lsp_provider_id": "I1",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "1",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "name": "Standard Delivery",
+                        "code": "P2H2P",
+                        "short_desc": "Fast Delivery For Items",
+                        "long_desc": "Fast Delivery for Items"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "1",
+                      "price": {
+                        "currency": "INR",
+                        "value": "69"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "timestamp": "2025-04-28",
+                        "duration": "P5D"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c28~19537~YAARI-19537-20250424-U2JJE6IXS4~SY-1745516797923-51",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "395.74"
+                    },
+                    "lsp_provider_id": "19537",
+                    "lsp_fulfillment_id": "SY-1745516797923-51",
+                    "lsp_item_details": {
+                      "id": "YAARI-19537-20250424-U2JJE6IXS4",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "SY-1745516797923-51",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Ecom Express",
+                        "short_desc": "Ecom Express",
+                        "long_desc": "Ecom Express"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "395.74"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "2.0"
+                    },
+                    "lsp_provider_id": "NS_LSP",
+                    "lsp_fulfillment_id": "ns_immediate_f1",
+                    "lsp_item_details": {
+                      "id": "ns_immediate",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "ns_immediate_f1",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "NS LSP Immediate Delivery",
+                        "short_desc": "Immediate Delivery by NS LSP",
+                        "long_desc": "Immediate Delivery by NS LSP"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2.0"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT55M",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    },
+                    "lsp_provider_id": "NS_LSP",
+                    "lsp_fulfillment_id": "ns_immediate_f1-RTO",
+                    "lsp_item_details": {
+                      "id": "ns_immediate-RTO",
+                      "parent_item_id": "ns_immediate",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "ns_immediate_f1-RTO",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "RTO quote",
+                        "short_desc": "RTO quote",
+                        "long_desc": "RTO quote"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "0"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT55M",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                    "lsp_item_details": {
+                      "id": "imd_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Immediate Delivery",
+                        "long_desc": "Upto 60 mins for Delivery",
+                        "short_desc": "Upto 60 mins for Delivery"
+                      },
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~a60ad63c-b760-42be-98e0-6022237da726",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "a60ad63c-b760-42be-98e0-6022237da726",
+                    "lsp_item_details": {
+                      "id": "exp_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Express Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Express Delivery",
+                      "fulfillment_id": "a60ad63c-b760-42be-98e0-6022237da726",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                    "lsp_item_details": {
+                      "id": "nex_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Next Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Next Day Delivery",
+                      "fulfillment_id": "a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                    "lsp_item_details": {
+                      "id": "same_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Same Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Same Day Delivery",
+                      "fulfillment_id": "1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2b~Delhivery~3204dd9f-423a-46a7-8b94-f11642a83977~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "7500.72"
+                    },
+                    "lsp_provider_id": "Delhivery",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "3204dd9f-423a-46a7-8b94-f11642a83977",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "1",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Standard Delivery",
+                        "short_desc": "Delhivery Surface",
+                        "long_desc": "Delhivery Surface"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "7500.72"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P4D",
+                        "timestamp": "2025-04-28"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2c~P1~I1~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "59.00"
+                    },
+                    "lsp_provider_id": "P1",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "I1",
+                      "parent_item_id": "",
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "1",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "60 min delivery",
+                        "short_desc": "60 min delivery for F&B",
+                        "long_desc": "60 min delivery for F&B"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "59.00"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2023-06-06"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c2f~MOVERDELIVERY~I1~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "25527"
+                    },
+                    "lsp_provider_id": "MOVERDELIVERY",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "I1",
+                      "parent_item_id": "",
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "1",
+                      "descriptor": {
+                        "name": "30 min delivery",
+                        "short_desc": "30 min delivery for F&B",
+                        "long_desc": "30 min delivery for F&B",
+                        "code": "P2P"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "25527"
+                      },
+                      "time": {
+                        "duration": "PT30M",
+                        "label": "TAT",
+                        "timestamp": "2025-04-24T17:46:39.1265809Z"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c30~Bluedart Express~BDEEP0~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "1388.29"
+                    },
+                    "lsp_provider_id": "Bluedart Express",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "BDEEP0",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "1",
+                      "descriptor": {
+                        "name": "Dart Surface Etail",
+                        "code": "P2H2P",
+                        "short_desc": "Standard Delivery",
+                        "long_desc": "Standard Delivery"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "timestamp": "2025-04-28",
+                        "duration": "P4D"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "1388.29"
+                      },
+                      "parent_item_id": ""
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c31~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "815.00"
+                    },
+                    "lsp_provider_id": "DTDC",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "B2C SMART EXPRESS",
+                      "category_id": "Standard Delivery",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Standard Delivery",
+                        "short_desc": "B2C SMART EXPRESS",
+                        "long_desc": "3 - 4 Day/s"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "815.00"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P4D",
+                        "timestamp": "2025-04-28"
+                      },
+                      "fulfillment_id": "1"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c32~P1~I1~I1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "65560.00"
+                    },
+                    "lsp_provider_id": "P1",
+                    "lsp_fulfillment_id": "I1",
+                    "lsp_item_details": {
+                      "id": "I1",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "I1",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Standard",
+                        "short_desc": "Standard",
+                        "long_desc": "Standard"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "65560.00"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P8D",
+                        "timestamp": "2025-04-24T17:46:40.323020Z"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c27~I1~1~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c27~I1~1~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c27~I1~1~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c28~19537~YAARI-19537-20250424-U2JJE6IXS4~SY-1745516797923-51",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c28~19537~YAARI-19537-20250424-U2JJE6IXS4~SY-1745516797923-51",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c28~19537~YAARI-19537-20250424-U2JJE6IXS4~SY-1745516797923-51",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c29~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8bfdc3ae-c9c7-4b73-9f0c-f335d4c00b05",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~a60ad63c-b760-42be-98e0-6022237da726",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~a60ad63c-b760-42be-98e0-6022237da726",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~a60ad63c-b760-42be-98e0-6022237da726",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~a1b33f03-8c37-4385-ae2c-0c2a6f150965",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~1eb01f3f-66d8-4a3b-8550-fc47f6f77db7",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2b~Delhivery~3204dd9f-423a-46a7-8b94-f11642a83977~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2b~Delhivery~3204dd9f-423a-46a7-8b94-f11642a83977~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2b~Delhivery~3204dd9f-423a-46a7-8b94-f11642a83977~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2c~P1~I1~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2c~P1~I1~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2c~P1~I1~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c2f~MOVERDELIVERY~I1~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c2f~MOVERDELIVERY~I1~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c2f~MOVERDELIVERY~I1~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c30~Bluedart Express~BDEEP0~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c30~Bluedart Express~BDEEP0~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78ff48665475e6bf8c30~Bluedart Express~BDEEP0~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c31~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c31~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c31~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c32~P1~I1~I1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c32~P1~I1~I1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a790048665475e6bf8c32~P1~I1~I1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "ttl": "P1D"
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "accept_bap_terms",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_select",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "40b6f53d-ac0d-4739-ac1d-2408a3445482",
+            "timestamp": "2025-04-24T17:46:45.092Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "init_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745516858\",expires=\"1745520458\",headers=\"(created) (expires) digest\",signature=\"Jzed6xAVfNkyWrjcsi0jsnV4+y+W8CPxbPWyeL1jSamIDQg8e/NvhPJb10+KN7UXrY2v6dJzrfO8nqJ+SZC6AA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "8d7b23b7-d2e0-46ff-a9a6-c080930836da",
+            "timestamp": "2025-04-24T17:47:38.997Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f589b8f7-ed7d-4fa7-8bef-9c07e4697385",
+            "timestamp": "2025-04-24T17:47:39.218Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_init_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745516862\",expires=\"1745546862703\",headers=\"(created) (expires) digest\",signature=\"SPLrwT2Y9tndstV5Ui23ZqBJ7WIQS60UEz+9njUSGo7C+hHCj5bNv3kRv3LGIbevHZcz55dEVoIrbsGgxS+cBA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "8d7b23b7-d2e0-46ff-a9a6-c080930836da",
+            "timestamp": "2025-04-24T17:47:42.694Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "currency": "INR",
+                  "amount": "0"
+                },
+                "status": "NOT-PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "return_window_expiry",
+                "@ondc/org/settlement_window": "P2D",
+                "@ondc/org/withholding_amount": "0",
+                "@ondc/org/collected_by_status": "Assert",
+                "collected_by": "BPP"
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "8d7b23b7-d2e0-46ff-a9a6-c080930836da",
+            "timestamp": "2025-04-24T17:47:42.694Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "confirm_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745516875\",expires=\"1745520475\",headers=\"(created) (expires) digest\",signature=\"S0529JgBQnz2ms8HVamaFAiI0g1wAojFAaiPAN/sAJkXSGUwvZS38d9MnNAkI25ufNmEavG4FpvJYp+mQeSDCA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "confirm",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f7ab3502-9e65-44fb-a9c7-e2f8b150df53",
+            "timestamp": "2025-04-24T17:47:55.776Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "Created",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "person": {
+                      "name": "Nirdosh Chauhan"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                },
+                {
+                  "code": "bap_terms",
+                  "list": [
+                    {
+                      "code": "tax_number",
+                      "value": "00XYZAB1234C1Z8"
+                    },
+                    {
+                      "code": "accept_bpp_terms",
+                      "value": "Y"
+                    }
+                  ]
+                }
+              ],
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Assert",
+                "collected_by": "BAP"
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:47:55.776Z"
+            }
+          }
+        },
+        "response": {
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_confirm_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745516881\",expires=\"1745546881269\",headers=\"(created) (expires) digest\",signature=\"I9/+33Jfl2pFXhc6yeqvwnnVni+igJPZaU5d3i8vw7AE/oxndpdhTJ71kUXm9SHoK82bWsO3tKDsGR2OmPgJDA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f7ab3502-9e65-44fb-a9c7-e2f8b150df53",
+            "timestamp": "2025-04-24T17:48:01.262Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "Created",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T17:30:00.000Z",
+                        "end": "2025-04-24T19:30:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code",
+                      "long_desc": ""
+                    },
+                    "time": {
+                      "range": {
+                        "end": "2025-04-24T17:51:01.245Z"
+                      }
+                    }
+                  },
+                  "state": {
+                    "descriptor": {
+                      "code": "Pending",
+                      "name": "Getting ready for shipment (packaging)"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                },
+                {
+                  "code": "bap_terms",
+                  "list": [
+                    {
+                      "code": "tax_number",
+                      "value": "00XYZAB1234C1Z8"
+                    },
+                    {
+                      "code": "accept_bpp_terms",
+                      "value": "Y"
+                    }
+                  ]
+                }
+              ],
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Assert",
+                "collected_by": "BAP"
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:48:01.262Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f7ab3502-9e65-44fb-a9c7-e2f8b150df53",
+            "timestamp": "2025-04-24T17:48:01.262Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517220\",expires=\"1745547220121\",headers=\"(created) (expires) digest\",signature=\"+yWQsU8Y+FjzdLJ8at2F9iZ2GhavsUngnq9ZTLvIwJxdPHOeTB+XaPtqXX5RfN0EUxlsOi+xWm1EHknZGXeRAA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "6176f8bc-891e-4b23-8785-bf0536514039",
+            "timestamp": "2025-04-24T17:53:40.102Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "Accepted",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T17:30:00.000Z",
+                        "end": "2025-04-24T19:30:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code",
+                      "long_desc": ""
+                    },
+                    "time": {
+                      "range": {
+                        "end": "2025-04-24T17:51:01.245Z"
+                      }
+                    }
+                  },
+                  "state": {
+                    "descriptor": {
+                      "code": "Pending",
+                      "name": "Getting ready for shipment (packaging)"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "6176f8bc-891e-4b23-8785-bf0536514039",
+            "timestamp": "2025-04-24T17:53:40.102Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_2": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517229\",expires=\"1745547229038\",headers=\"(created) (expires) digest\",signature=\"CYE/3sCB7dXuoSsW5n+e83JuG5I4ObTYwosRK6qqPkqgPzufcsbdoYJM85zssBW/02peZUtgaxE/I4oPGt13Dg==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "ee0e53b0-dc1f-450f-b553-feca04d4ebde",
+            "timestamp": "2025-04-24T17:53:49.025Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Packed",
+                      "name": "Packaging completed. Ready to ship"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "ee0e53b0-dc1f-450f-b553-feca04d4ebde",
+            "timestamp": "2025-04-24T17:53:49.025Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_3": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517244\",expires=\"1745547244178\",headers=\"(created) (expires) digest\",signature=\"KEFJRTZNS+VgP/QdCyHyNbwfMkbTxlh2U4CEKHB3c6lBx8Pji9qrKbYfa08qVR55rhZRUwipYEvwkQtRx9g3Ag==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "7f56ff15-2533-4ba3-a9e3-c59ed0a5f759",
+            "timestamp": "2025-04-24T17:54:04.169Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Agent-assigned",
+                      "name": "Agent assigned"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "7f56ff15-2533-4ba3-a9e3-c59ed0a5f759",
+            "timestamp": "2025-04-24T17:54:04.169Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_4": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517247\",expires=\"1745547247177\",headers=\"(created) (expires) digest\",signature=\"0fxYHI6HsX7SGCzhueSvSZ+Trc40WeswVZYfD+yZoMHGwJtNsFJRhEPM/a5qy9cFbwbGx4PGz2A2Vvl8wr12Ag==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "1f4212dc-6b3c-4469-b161-fb85b860c145",
+            "timestamp": "2025-04-24T17:54:07.166Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-picked-up",
+                      "name": "Product picked up from the source and shipment started"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:07.007Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "1f4212dc-6b3c-4469-b161-fb85b860c145",
+            "timestamp": "2025-04-24T17:54:07.166Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_5": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517254\",expires=\"1745547254622\",headers=\"(created) (expires) digest\",signature=\"ItB/zR0JCdJxBgUG/dZnO5xQ7+0uul9dTEp2Vv08qFoXxQx5rqCZOmhOyLjXy9f0sROvFzrS0QVeP7nQ8dxbCQ==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "b7fde458-3c07-466a-9c52-a29cc17515ba",
+            "timestamp": "2025-04-24T17:54:14.614Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Out-for-delivery",
+                      "name": "Product would be delivered soon"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:07.007Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "b7fde458-3c07-466a-9c52-a29cc17515ba",
+            "timestamp": "2025-04-24T17:54:14.614Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "track_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745517265\",expires=\"1745520865\",headers=\"(created) (expires) digest\",signature=\"BVXdJVXK9cwfk/uZ6DWF0BI2luPJ26DlX71e3oCDG7eYl4E7flPezyGV0yTj3dlC6oy1vrGKg/C9PEARmuvUAA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "track",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "a3d30a32-0708-44c5-a646-ac14b38820af",
+            "timestamp": "2025-04-24T17:54:25.862Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order_id": "SS1745516875776"
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_track",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "5e2d673d-f5e6-4916-803d-1aebba93e932",
+            "timestamp": "2025-04-24T17:54:25.898Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_track_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517267\",expires=\"1745547267538\",headers=\"(created) (expires) digest\",signature=\"byeIqrTQw8pjhTCvgrQS9ykvdB7W3W9+ceZWvAkYxco0zB5iUZnExUPCF/zVEnxIFykmnAW5wYhyIH+f1QrqBw==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_track",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f7ab3502-9e65-44fb-a9c7-e2f8b150df53",
+            "timestamp": "2025-04-24T17:54:27.518Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "tracking": {
+              "id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+              "url": "http://sequelstring-lsp-ondc.com/track",
+              "location": {
+                "gps": "12.974002,77.613458",
+                "time": {
+                  "timestamp": "2025-04-24T17:54:27.374Z"
+                },
+                "updated_at": "2025-04-24T17:54:27.374Z"
+              },
+              "status": "active",
+              "tags": [
+                {
+                  "code": "order",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "SS1745516875776"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "attr",
+                      "value": "tracking.location.gps"
+                    },
+                    {
+                      "code": "type",
+                      "value": "live_poll"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_track",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "f7ab3502-9e65-44fb-a9c7-e2f8b150df53",
+            "timestamp": "2025-04-24T17:54:27.518Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_6": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517290\",expires=\"1745547290243\",headers=\"(created) (expires) digest\",signature=\"lXnxFQYfX/dBCFUXUA69SSnLRhszNlAo5N6vws/ndRiKsn8ntMLEFzIvpvctiLgQyby/h7yzgRgbibwjONJ/Ag==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "a023fe86-d0aa-4b8f-a1d2-fc74e0d4522a",
+            "timestamp": "2025-04-24T17:54:50.236Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Out-for-delivery",
+                      "name": "Product would be delivered soon"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:07.007Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "a023fe86-d0aa-4b8f-a1d2-fc74e0d4522a",
+            "timestamp": "2025-04-24T17:54:50.236Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_7": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517297\",expires=\"1745547297986\",headers=\"(created) (expires) digest\",signature=\"fis1epjkeNF7MqMAxogXugwv8fJSenz/o1MssLnxHOhRW5T4aep7/YxWU81vbo0wX7lOjG5UoEDAAruE7qH0AQ==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "7ca40130-bbbf-4d31-a104-bb4fe46b3ccd",
+            "timestamp": "2025-04-24T17:54:57.977Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "Completed",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-delivered",
+                      "name": "Product delivered"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:07.007Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:57.800Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Delivery",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "7ca40130-bbbf-4d31-a104-bb4fe46b3ccd",
+            "timestamp": "2025-04-24T17:54:57.977Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_8": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517304\",expires=\"1745547304831\",headers=\"(created) (expires) digest\",signature=\"/JNAYshtiEoFt5VbvqPBtsgArmsW53GSybybm/afCvE93jxKuFnuRTrVFpHWnFG9WsjnwSG0n6QONGHSNcReAA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "43e8cf4a-af4e-40c5-b91e-d58f5535f02a",
+            "timestamp": "2025-04-24T17:55:04.820Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745516875776",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T17:47:38.997Z",
+                "updated_at": "2025-04-24T17:47:38.997Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-delivered",
+                      "name": "Product delivered"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:07.007Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T17:54:57.800Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Delivery",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "196e42be-1ccd-4f20-b660-1aa9573e683a"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:47:55.776Z",
+              "updated_at": "2025-04-24T17:53:40.032Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "message_id": "43e8cf4a-af4e-40c5-b91e-d58f5535f02a",
+            "timestamp": "2025-04-24T17:55:04.820Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "issue_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745517512\",expires=\"1745521112\",headers=\"(created) (expires) digest\",signature=\"HakTFZfgIl4qd6yzT7S10VQHJUzKBBywGmcRSDk+fbYOrbP0A8j5EkpcRhLc+tPCi8QoHIzxfnJyXhTMernXCA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "city": "std:080",
+            "country": "IND",
+            "core_version": "1.2.0",
+            "action": "issue",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "ttl": "PT30M",
+            "message_id": "cc9f1cd8-b3cf-4086-862d-3773db30afe1",
+            "timestamp": "2025-04-24T17:58:32.514Z"
+          },
+          "message": {
+            "issue": {
+              "id": "SS1745516712292",
+              "category": "ITEM",
+              "sub_category": "ITM03",
+              "complainant_info": {
+                "contact": {
+                  "email": "mail@ayushyadav.tech",
+                  "phone": "9990202525"
+                },
+                "person": {
+                  "name": "Ayush Yadav"
+                }
+              },
+              "order_details": {
+                "id": "SS1745516875776",
+                "state": "Created",
+                "provider_id": "674ecb33d7b9e10f4210d972",
+                "fulfillments": [
+                  {
+                    "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                    "state": "Pending"
+                  }
+                ],
+                "items": [
+                  {
+                    "id": "676a6179cac4860876a8e30b",
+                    "quantity": 2
+                  },
+                  {
+                    "id": "676a6126cac4860876a8e309",
+                    "quantity": 3
+                  }
+                ]
+              },
+              "description": {
+                "short_desc": "Some short description",
+                "long_desc": "Some long description",
+                "additional_desc": {
+                  "url": "https://ondc.org/assets/theme/images/ondc_registered_logo.svg?v=399788fda7",
+                  "content_type": "image/png"
+                },
+                "images": [
+                  "https://ondc.org/assets/theme/images/ondc_registered_logo.svg?v=399788fda7"
+                ]
+              },
+              "source": {
+                "network_participant_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+                "type": "CONSUMER"
+              },
+              "expected_response_time": {
+                "duration": "PT2H"
+              },
+              "expected_resolution_time": {
+                "duration": "P1D"
+              },
+              "status": "OPEN",
+              "issue_type": "ISSUE",
+              "issue_actions": {
+                "complainant_actions": [
+                  {
+                    "complainant_action": "OPEN",
+                    "short_desc": "Complaint created",
+                    "updated_at": "2025-04-24T17:58:32.513Z",
+                    "updated_by": {
+                      "org": {
+                        "name": "pramaan.ondc.org/beta/preprod/mock/buyer::ONDC:RET10"
+                      },
+                      "contact": {
+                        "phone": "9033891671",
+                        "email": "abc@ondc.in"
+                      },
+                      "person": {
+                        "name": "Support Desk"
+                      }
+                    }
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T17:58:32.513Z",
+              "updated_at": "2025-04-24T17:58:32.513Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "city": "std:080",
+            "country": "IND",
+            "core_version": "1.2.0",
+            "action": "issue",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+            "ttl": "PT30M",
+            "message_id": "cc9f1cd8-b3cf-4086-862d-3773db30afe1",
+            "timestamp": "2025-04-24T17:58:32.514Z"
+          },
+          "message": {
+            "ack": {
+              "status": "NACK"
+            }
+          },
+          "error": {
+            "type": "DOMAIN-ERROR",
+            "code": "30000",
+            "message": "Invalid request"
+          }
+        }
+      }
+    }
+  }

--- a/Lekhha/Retail-Logistics/Flow_A3_IGM/Retail_issue
+++ b/Lekhha/Retail-Logistics/Flow_A3_IGM/Retail_issue
@@ -1,0 +1,100 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "city": "std:080",
+          "country": "IND",
+          "core_version": "1.2.0",
+          "action": "issue",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "transaction_id": "d4efc8ce-7ece-4971-96a3-76f51fc75505",
+          "ttl": "PT30M",
+          "message_id": "cc9f1cd8-b3cf-4086-862d-3773db30afe1",
+          "timestamp": "2025-04-24T17:58:32.514Z"
+        },
+        "message": {
+          "issue": {
+            "id": "SS1745516712292",
+            "category": "ITEM",
+            "sub_category": "ITM03",
+            "complainant_info": {
+              "contact": {
+                "email": "mail@ayushyadav.tech",
+                "phone": "9990202525"
+              },
+              "person": {
+                "name": "Ayush Yadav"
+              }
+            },
+            "order_details": {
+              "id": "SS1745516875776",
+              "state": "Created",
+              "provider_id": "674ecb33d7b9e10f4210d972",
+              "fulfillments": [
+                {
+                  "id": "680a78fe48665475e6bf8c2a~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~7d2be13f-3703-4e7a-b9a7-0afb1505df7f",
+                  "state": "Pending"
+                }
+              ],
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "quantity": 2
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "quantity": 3
+                }
+              ]
+            },
+            "description": {
+              "short_desc": "Some short description",
+              "long_desc": "Some long description",
+              "additional_desc": {
+                "url": "https://ondc.org/assets/theme/images/ondc_registered_logo.svg?v=399788fda7",
+                "content_type": "image/png"
+              },
+              "images": [
+                "https://ondc.org/assets/theme/images/ondc_registered_logo.svg?v=399788fda7"
+              ]
+            },
+            "source": {
+              "network_participant_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+              "type": "CONSUMER"
+            },
+            "expected_response_time": {
+              "duration": "PT2H"
+            },
+            "expected_resolution_time": {
+              "duration": "P1D"
+            },
+            "status": "OPEN",
+            "issue_type": "ISSUE",
+            "issue_actions": {
+              "complainant_actions": [
+                {
+                  "complainant_action": "OPEN",
+                  "short_desc": "Complaint created",
+                  "updated_at": "2025-04-24T17:58:32.513Z",
+                  "updated_by": {
+                    "org": {
+                      "name": "pramaan.ondc.org/beta/preprod/mock/buyer::ONDC:RET10"
+                    },
+                    "contact": {
+                      "phone": "9033891671",
+                      "email": "abc@ondc.in"
+                    },
+                    "person": {
+                      "name": "Support Desk"
+                    }
+                  }
+                }
+              ]
+            },
+            "created_at": "2025-04-24T17:58:32.513Z",
+            "updated_at": "2025-04-24T17:58:32.513Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Downloaded_logs_LBNP.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Downloaded_logs_LBNP.json
@@ -1,0 +1,3279 @@
+{
+    "domain": "nic2004:60232",
+    "payload": {
+      "search_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517590\",expires=\"1745547590882\",headers=\"(created) (expires) digest\",signature=\"5n70HkPDqnPl6qQOx6ANgSXCUVq/9xgxDnVax9rWGeKSXCM33hZOojYzmeCZWHABxN8zLSBY6uHSengvRzMNDw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "search",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "162777d5-ee92-43a0-ac39-cbc83e272f82",
+            "timestamp": "2025-04-24T17:59:50.882Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "intent": {
+              "category": {
+                "id": "Standard Delivery"
+              },
+              "provider": {
+                "time": {
+                  "days": "1,2,3,4,5,6,7",
+                  "schedule": {
+                    "holidays": []
+                  },
+                  "duration": "P0DT0H1M",
+                  "range": {
+                    "start": "0001",
+                    "end": "2359"
+                  }
+                }
+              },
+              "fulfillment": {
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "area_code": "560103"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              "payment": {
+                "type": "ON-ORDER"
+              },
+              "@ondc/org/payload_details": {
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                },
+                "category": "Grocery",
+                "value": {
+                  "currency": "INR",
+                  "value": "880"
+                },
+                "dangerous_goods": false
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "search",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "162777d5-ee92-43a0-ac39-cbc83e272f82",
+            "timestamp": "2025-04-24T17:59:50.882Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_search_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517591\",expires=\"1745521191\",headers=\"(created) (expires) digest\",signature=\"DCtQSy/HMbjKO3imuuav8YCpzDiEp5GFn2o5OEhK5Xb4xRKigPaLdv3SsFuauD123sRjo8Q9rl9mWu657B8WAQ==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "162777d5-ee92-43a0-ac39-cbc83e272f82",
+            "timestamp": "2025-04-24T17:59:51.932Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "catalog": {
+              "bpp/descriptor": {
+                "name": "ONDC Pramaaan Logistics"
+              },
+              "bpp/providers": [
+                {
+                  "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "descriptor": {
+                    "name": "ONDC Pramaaan Logistics",
+                    "short_desc": "Swiftly Yours, Delivered with Care",
+                    "long_desc": "We deliver everywhere—yes, even Mars (just give us a little more rocket fuel)."
+                  },
+                  "categories": [
+                    {
+                      "id": "Standard Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "Immediate Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      }
+                    },
+                    {
+                      "id": "Express Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "Next Day Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "Same Day Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  ],
+                  "fulfillments": [
+                    {
+                      "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT15M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT20M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "37260627-31f5-461f-b01c-67c16a6b69b3",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT30M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "5476be14-c110-4772-a03b-8d28924827bc",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT30M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "ed4b869a-0023-4bcf-a533-a0536667b63f",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT15M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "80262053-367c-4eb0-a081-57549dfdf841",
+                      "type": "RTO"
+                    }
+                  ],
+                  "items": [
+                    {
+                      "id": "rto_std",
+                      "parent_item_id": "std_del",
+                      "category_id": "Standard Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "fulfillment_id": "80262053-367c-4eb0-a081-57549dfdf841",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "rto_imd",
+                      "parent_item_id": "imd_del",
+                      "category_id": "Immediate Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Immediate Delivery",
+                        "long_desc": "Upto 60 mins for Delivery",
+                        "short_desc": "Upto 60 mins for Delivery"
+                      },
+                      "fulfillment_id": "80262053-367c-4eb0-a081-57549dfdf841",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "imd_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Immediate Delivery",
+                        "long_desc": "Upto 60 mins for Delivery",
+                        "short_desc": "Upto 60 mins for Delivery"
+                      },
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      }
+                    },
+                    {
+                      "id": "rto_exp",
+                      "parent_item_id": "exp_del",
+                      "category_id": "Express Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Express Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "fulfillment_id": "80262053-367c-4eb0-a081-57549dfdf841",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "exp_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Express Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Express Delivery",
+                      "fulfillment_id": "37260627-31f5-461f-b01c-67c16a6b69b3",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "rto_nex",
+                      "parent_item_id": "nex_del",
+                      "category_id": "Next Day Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Next Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "fulfillment_id": "80262053-367c-4eb0-a081-57549dfdf841",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "nex_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Next Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Next Day Delivery",
+                      "fulfillment_id": "5476be14-c110-4772-a03b-8d28924827bc",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "rto_same",
+                      "parent_item_id": "same_del",
+                      "category_id": "Same Day Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Same Day Delivery",
+                        "long_desc": "Same Delivery",
+                        "short_desc": "Same for Delivery"
+                      },
+                      "fulfillment_id": "80262053-367c-4eb0-a081-57549dfdf841",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "same_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Same Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Same Day Delivery",
+                      "fulfillment_id": "ed4b869a-0023-4bcf-a533-a0536667b63f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "162777d5-ee92-43a0-ac39-cbc83e272f82",
+            "timestamp": "2025-04-24T17:59:51.932Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK",
+              "tags": [
+                {
+                  "display": true,
+                  "code": "string",
+                  "name": "string",
+                  "list": [
+                    {
+                      "code": "string",
+                      "name": "string",
+                      "value": "string",
+                      "display": true
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "error": {
+            "type": "CONTEXT-ERROR",
+            "code": "string",
+            "path": "string",
+            "message": "string"
+          }
+        }
+      },
+      "init_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517622\",expires=\"1745547622865\",headers=\"(created) (expires) digest\",signature=\"FrMuChNNCbfLtFLwo4UyBVQONBrtm3cytzBaOlmMXFf3jIKb+6hj38iNxLTDoHS/i2uI7x/gTtxYXDxwyWXECg==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "d33c7a24-7cbc-4b85-8f6d-6807019414ae",
+            "timestamp": "2025-04-24T18:00:22.865Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "category_id": "Standard Delivery",
+                  "descriptor": {
+                    "code": "P2P"
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "d33c7a24-7cbc-4b85-8f6d-6807019414ae",
+            "timestamp": "2025-04-24T18:00:22.865Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_init_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517622\",expires=\"1745521222\",headers=\"(created) (expires) digest\",signature=\"+75MRKxN61IPwZLHM9oK99eZudLtsOJqR1BYgpZ+E+MFGXXsdppKqv1aOtGgo950gEdjRPjReEhLxgEBXba+Ag==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "d33c7a24-7cbc-4b85-8f6d-6807019414ae",
+            "timestamp": "2025-04-24T18:00:22.909Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  }
+                }
+              ],
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ],
+                "ttl": "P7D"
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "d33c7a24-7cbc-4b85-8f6d-6807019414ae",
+            "timestamp": "2025-04-24T18:00:22.909Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK",
+              "tags": [
+                {
+                  "display": true,
+                  "code": "string",
+                  "name": "string",
+                  "list": [
+                    {
+                      "code": "string",
+                      "name": "string",
+                      "value": "string",
+                      "display": true
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "confirm_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517638\",expires=\"1745547638517\",headers=\"(created) (expires) digest\",signature=\"xtXADHIl3yvQSqV0OW7Uw/y+EyziT/cBkRmIpDAv9FNxDDm4nJxZSY+8E3MPP0lyuXqem8fuG3+dP3eeATmwAQ==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "confirm",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "5dcd7590-fd8b-41da-9d16-5b2698b51069",
+            "timestamp": "2025-04-24T18:00:38.517Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "category_id": "Standard Delivery",
+                  "descriptor": {
+                    "code": "P2P"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "id": "SS1745517638223",
+              "state": "Created",
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517638223",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "tags": [
+                {
+                  "code": "bap_terms",
+                  "list": [
+                    {
+                      "code": "accept_bpp_terms",
+                      "value": "Y"
+                    }
+                  ]
+                }
+              ],
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:00:38.476Z"
+            }
+          }
+        },
+        "response": {
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_confirm_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517638\",expires=\"1745521238\",headers=\"(created) (expires) digest\",signature=\"fyKspZ6VLYC9MhulB50PY3uzD+bws3KJgZx7bwlzFwSEMjQWmwVh9RQD5pDaniBuN93TluB8nVJVxCweXrXUBA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "5dcd7590-fd8b-41da-9d16-5b2698b51069",
+            "timestamp": "2025-04-24T18:00:38.562Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "Accepted",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Pending"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517638223",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:00:38.562Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "5dcd7590-fd8b-41da-9d16-5b2698b51069",
+            "timestamp": "2025-04-24T18:00:38.562Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "update_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517674\",expires=\"1745547674451\",headers=\"(created) (expires) digest\",signature=\"dYv7fo1yn72KZWQWiLY9ca9xYmWmuLGivNgjYClpHBS4WTwfHvPMB2Ic7zSPS5qAp4g/ifEim4IZD6t2pSCyDw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "update",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "fe2f028b-cb77-4be1-aec0-3eb3d4c9b7cc",
+            "timestamp": "2025-04-24T18:01:14.451Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "update_target": "fulfillment",
+            "order": {
+              "id": "SS1745517638223",
+              "state": "Created",
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "descriptor": {
+                    "code": "P2P"
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship",
+                          "value": "yes"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "updated_at": "2025-04-24T23:31:14.439Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "update",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "fe2f028b-cb77-4be1-aec0-3eb3d4c9b7cc",
+            "timestamp": "2025-04-24T18:01:14.451Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_update_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517680\",expires=\"1745521280\",headers=\"(created) (expires) digest\",signature=\"4BLzhxEqruhKtvuPVZ8vuy3VHbZM3aUB2OwX9QB2Q7tyagyskQfkGA9atcNkcezbE+lMRSTI4tWfJTk4BEkOAQ==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_update",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "fe2f028b-cb77-4be1-aec0-3eb3d4c9b7cc",
+            "timestamp": "2025-04-24T18:01:20.293Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "Accepted",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Searching-for-Agent"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517638223",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:00:38.562Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_update",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "fe2f028b-cb77-4be1-aec0-3eb3d4c9b7cc",
+            "timestamp": "2025-04-24T18:01:20.293Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517689\",expires=\"1745521289\",headers=\"(created) (expires) digest\",signature=\"XfIMCsOTilPrXYMbOziH2+Ll+cyuJvkdp4C0n3nixSgpcM1OFbLkZH5v3lbSKSxsbE90AQJtDj9gEXr3uoEdBA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "6ceed9b2-dc07-4084-970b-7f502bda4dd3",
+            "timestamp": "2025-04-24T18:01:29.464Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "In-progress",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Agent-assigned"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517638223",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:01:29.464Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "6ceed9b2-dc07-4084-970b-7f502bda4dd3",
+            "timestamp": "2025-04-24T18:01:29.464Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_2": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517695\",expires=\"1745521295\",headers=\"(created) (expires) digest\",signature=\"ZjMTXg5ZfYSLK2zvCQGPeQ9nRYsqEhtQOHLXx8OXYTdFX/83kCOr1Ef9fnVVpU5ozOUzLFrC4BXwTeXvyMWkBw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "ef2ce20b-0b88-4b6b-a253-774749b55bf8",
+            "timestamp": "2025-04-24T18:01:35.578Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "In-progress",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-picked-up"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:01:35.578Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "status": "NOT-PAID"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517638223",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:01:35.578Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "ef2ce20b-0b88-4b6b-a253-774749b55bf8",
+            "timestamp": "2025-04-24T18:01:35.578Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_3": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517701\",expires=\"1745521301\",headers=\"(created) (expires) digest\",signature=\"Iz4M1+ZqqmTZQ8BCS/AaMSeaOdwllQzZBGbynft/Ttw152ZFZ0h0HiFRtiCA87ccWtIsaZxsyUxyf7eGbt9ABQ==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "799d6106-8ce9-413d-9f53-a4ec1f817330",
+            "timestamp": "2025-04-24T18:01:41.598Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "In-progress",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Out-for-delivery"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:01:35.578Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "status": "NOT-PAID"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517638223",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:01:41.598Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "799d6106-8ce9-413d-9f53-a4ec1f817330",
+            "timestamp": "2025-04-24T18:01:41.598Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "status_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517727\",expires=\"1745547727580\",headers=\"(created) (expires) digest\",signature=\"E0+2P18R0rfceWez25ODV7nWNEr7bphdRCXk4jRHusoPf3YB67UlEfeN0wGWzFld5WLXiO4ArWMNikecZxsLBQ==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "6e45ee7e-4951-4754-bafd-5dbde78d723e",
+            "timestamp": "2025-04-24T18:02:07.580Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order_id": "SS1745517638223"
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "6e45ee7e-4951-4754-bafd-5dbde78d723e",
+            "timestamp": "2025-04-24T18:02:07.580Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_4": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517729\",expires=\"1745521329\",headers=\"(created) (expires) digest\",signature=\"ZZpXYkQ7xA7g+QheB55P7rVXodh4gO4mHIIogdNMky8AmsXgD7soz3aVp1bz0zeNR7K1rNu78YfEZSzbJ4nNDw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "6e45ee7e-4951-4754-bafd-5dbde78d723e",
+            "timestamp": "2025-04-24T18:02:09.065Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "In-progress",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Out-for-delivery"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:01:35.578Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "status": "NOT-PAID"
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517638223",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:01:41.598Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "6e45ee7e-4951-4754-bafd-5dbde78d723e",
+            "timestamp": "2025-04-24T18:02:09.065Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT10M"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_5": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517743\",expires=\"1745521343\",headers=\"(created) (expires) digest\",signature=\"yYuq8SsSArxD5MFi+NfLi/O1fjWqdvzKQGn+m5LTm437qsXnBrESoEfWabVLi+je8kSMFtHTla29fKCxfSxhAg==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "e8b8b775-a129-4890-afcd-165c74c8f9d1",
+            "timestamp": "2025-04-24T18:02:23.474Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "Completed",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-delivered"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:01:35.578Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:02:23.474Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Delivery",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "state",
+                      "list": [
+                        {
+                          "code": "ready_to_ship ",
+                          "value": "no"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "rto_action",
+                      "list": [
+                        {
+                          "code": "return_to_origin ",
+                          "value": "yes"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "tracking",
+                      "list": [
+                        {
+                          "code": "gps_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url_enabled",
+                          "value": "yes"
+                        },
+                        {
+                          "code": "url",
+                          "value": "http://sequelstring-lsp-ondc.com/track"
+                        }
+                      ]
+                    }
+                  ],
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "status": "NOT-PAID",
+                "time": {
+                  "timestamp": "2025-04-24T18:02:23.474Z"
+                }
+              },
+              "@ondc/org/linked_order": {
+                "items": [
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 2,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 10
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.000"
+                    }
+                  },
+                  {
+                    "category_id": "Grocery",
+                    "descriptor": {
+                      "name": "Milk blue"
+                    },
+                    "quantity": {
+                      "count": 3,
+                      "measure": {
+                        "unit": "unit",
+                        "value": 1
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.000"
+                    }
+                  }
+                ],
+                "provider": {
+                  "descriptor": {
+                    "name": "Lekhha Provider A"
+                  },
+                  "address": {
+                    "name": "Lekhha_Seller_1",
+                    "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                    "locality": "Bengaluru",
+                    "city": "Bengaluru",
+                    "state": "KA",
+                    "country": "IND",
+                    "area_code": "560103"
+                  }
+                },
+                "order": {
+                  "id": "SS1745517638223",
+                  "weight": {
+                    "unit": "gram",
+                    "value": 1720
+                  },
+                  "dimensions": {
+                    "length": {
+                      "unit": "centimeter",
+                      "value": 119
+                    },
+                    "breadth": {
+                      "unit": "centimeter",
+                      "value": 35
+                    },
+                    "height": {
+                      "unit": "centimeter",
+                      "value": 25
+                    }
+                  }
+                }
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:02:23.474Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "e8b8b775-a129-4890-afcd-165c74c8f9d1",
+            "timestamp": "2025-04-24T18:02:23.474Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT50S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      }
+    }
+  }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Downloaded_logs_LBNP_Buyer_Return.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Downloaded_logs_LBNP_Buyer_Return.json
@@ -1,0 +1,1893 @@
+{
+    "domain": "nic2004:60232",
+    "payload": {
+      "search_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517760\",expires=\"1745547760995\",headers=\"(created) (expires) digest\",signature=\"8+aZ2g5GgXd4a1/ZAjvAbBs8HIrQlmLf875puzwBQlNpfKlscWkox4O/58Msxb8m2T0LL6tKVovPA5xxNuYyDg==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "search",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "42f5db26-b841-4113-8173-3281489aeb2f",
+            "timestamp": "2025-04-24T18:02:40.995Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "intent": {
+              "category": {
+                "id": "Standard Delivery"
+              },
+              "provider": {
+                "time": {
+                  "days": "1,2,3,4,5,6,7",
+                  "schedule": {
+                    "holidays": []
+                  },
+                  "range": {
+                    "start": "0001",
+                    "end": "2359"
+                  }
+                }
+              },
+              "fulfillment": {
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "560103"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "area_code": "560103"
+                    }
+                  }
+                }
+              },
+              "payment": {
+                "type": "ON-ORDER"
+              },
+              "@ondc/org/payload_details": {
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                },
+                "category": "Grocery",
+                "value": {
+                  "currency": "INR",
+                  "value": "880"
+                },
+                "dangerous_goods": false
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "search",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "42f5db26-b841-4113-8173-3281489aeb2f",
+            "timestamp": "2025-04-24T18:02:40.995Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_search_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517761\",expires=\"1745521361\",headers=\"(created) (expires) digest\",signature=\"muyiJc1mx1xrJLGU2w5yCSvtyLsgosJ/f6zcmPYn5jn9UujntQ1CODFtblp+sALwQUgP6keQPiCCl5FI3SuICA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "42f5db26-b841-4113-8173-3281489aeb2f",
+            "timestamp": "2025-04-24T18:02:41.118Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "catalog": {
+              "bpp/descriptor": {
+                "name": "ONDC Pramaaan Logistics"
+              },
+              "bpp/providers": [
+                {
+                  "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "descriptor": {
+                    "name": "ONDC Pramaaan Logistics",
+                    "short_desc": "Swiftly Yours, Delivered with Care",
+                    "long_desc": "We deliver everywhere—yes, even Mars (just give us a little more rocket fuel)."
+                  },
+                  "categories": [
+                    {
+                      "id": "Standard Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "Immediate Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      }
+                    },
+                    {
+                      "id": "Express Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "Next Day Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "Same Day Delivery",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  ],
+                  "fulfillments": [
+                    {
+                      "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT15M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "135cc127-eef0-4f38-99de-71174bbcb5fb",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT20M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "201555bf-b31a-40f8-ac78-467088f92835",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT30M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "16c5b709-65fc-454c-ba9c-d6d9b5af3fe7",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT30M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "c27685b7-275b-4520-93ec-c5f84ba04c75",
+                      "type": "Delivery",
+                      "start": {
+                        "time": {
+                          "duration": "PT15M"
+                        }
+                      },
+                      "tags": [
+                        {
+                          "code": "distance",
+                          "list": [
+                            {
+                              "code": "motorable_distance_type",
+                              "value": "kilometer"
+                            },
+                            {
+                              "code": "motorable_distance",
+                              "value": "1728.04"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "64cfd1e4-8c1e-4465-b132-d1b820e79a8c",
+                      "type": "RTO"
+                    }
+                  ],
+                  "items": [
+                    {
+                      "id": "rto_std",
+                      "parent_item_id": "std_del",
+                      "category_id": "Standard Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "fulfillment_id": "64cfd1e4-8c1e-4465-b132-d1b820e79a8c",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "rto_imd",
+                      "parent_item_id": "imd_del",
+                      "category_id": "Immediate Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Immediate Delivery",
+                        "long_desc": "Upto 60 mins for Delivery",
+                        "short_desc": "Upto 60 mins for Delivery"
+                      },
+                      "fulfillment_id": "64cfd1e4-8c1e-4465-b132-d1b820e79a8c",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "imd_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Immediate Delivery",
+                        "long_desc": "Upto 60 mins for Delivery",
+                        "short_desc": "Upto 60 mins for Delivery"
+                      },
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "135cc127-eef0-4f38-99de-71174bbcb5fb",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      }
+                    },
+                    {
+                      "id": "rto_exp",
+                      "parent_item_id": "exp_del",
+                      "category_id": "Express Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Express Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "fulfillment_id": "64cfd1e4-8c1e-4465-b132-d1b820e79a8c",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "exp_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Express Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Express Delivery",
+                      "fulfillment_id": "201555bf-b31a-40f8-ac78-467088f92835",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "rto_nex",
+                      "parent_item_id": "nex_del",
+                      "category_id": "Next Day Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Next Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "fulfillment_id": "64cfd1e4-8c1e-4465-b132-d1b820e79a8c",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "nex_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Next Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Next Day Delivery",
+                      "fulfillment_id": "16c5b709-65fc-454c-ba9c-d6d9b5af3fe7",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    },
+                    {
+                      "id": "rto_same",
+                      "parent_item_id": "same_del",
+                      "category_id": "Same Day Delivery",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Same Day Delivery",
+                        "long_desc": "Same Delivery",
+                        "short_desc": "Same for Delivery"
+                      },
+                      "fulfillment_id": "64cfd1e4-8c1e-4465-b132-d1b820e79a8c",
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2612.06"
+                      }
+                    },
+                    {
+                      "id": "same_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Same Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Same Day Delivery",
+                      "fulfillment_id": "c27685b7-275b-4520-93ec-c5f84ba04c75",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "42f5db26-b841-4113-8173-3281489aeb2f",
+            "timestamp": "2025-04-24T18:02:41.118Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK",
+              "tags": [
+                {
+                  "display": true,
+                  "code": "string",
+                  "name": "string",
+                  "list": [
+                    {
+                      "code": "string",
+                      "name": "string",
+                      "value": "string",
+                      "display": true
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "error": {
+            "type": "CONTEXT-ERROR",
+            "code": "string",
+            "path": "string",
+            "message": "string"
+          }
+        }
+      },
+      "init_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517768\",expires=\"1745547768607\",headers=\"(created) (expires) digest\",signature=\"3+pP95OriH1f3FdGwu5Sb0NrdKGkUHiG0Jb9VUIw8R4xQiyX+EzPPkhHDVEVtmuUIChl1+gJO4T5aRBBTERACg==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "70890cdf-8ec0-408c-be98-9d62008f8673",
+            "timestamp": "2025-04-24T18:02:48.607Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                  "category_id": "Standard Delivery",
+                  "descriptor": {
+                    "code": "P2P"
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                  "type": "Delivery",
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "70890cdf-8ec0-408c-be98-9d62008f8673",
+            "timestamp": "2025-04-24T18:02:48.607Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_init_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517768\",expires=\"1745521368\",headers=\"(created) (expires) digest\",signature=\"khxe54aVQNBXE9gHNbm3oyQtqp7m5WajQgsDCpRtFj6yHZ/C3sZO4egwe0HCMGCM2Cs/4rpiSvIRLdtGpDwRBA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "70890cdf-8ec0-408c-be98-9d62008f8673",
+            "timestamp": "2025-04-24T18:02:48.640Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT10M",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434"
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                  "type": "Delivery",
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  }
+                }
+              ],
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ],
+                "ttl": "P7D"
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "70890cdf-8ec0-408c-be98-9d62008f8673",
+            "timestamp": "2025-04-24T18:02:48.640Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT10M",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK",
+              "tags": [
+                {
+                  "display": true,
+                  "code": "string",
+                  "name": "string",
+                  "list": [
+                    {
+                      "code": "string",
+                      "name": "string",
+                      "value": "string",
+                      "display": true
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "confirm_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517770\",expires=\"1745547770655\",headers=\"(created) (expires) digest\",signature=\"ZQhlyzsDnwnyHtLiuuLf2gMZ/l8zFAB7TbimyeTpA3Bo8KtRG2xX1qGFoWArM2f287HV3R70k4/8P1Q7y8wvBA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "confirm",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "f393797d-2d82-45ef-88ec-f419cb73f4ad",
+            "timestamp": "2025-04-24T18:02:50.655Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                  "category_id": "Standard Delivery",
+                  "descriptor": {
+                    "code": "P2P"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                  "type": "Delivery",
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  }
+                }
+              ],
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "state": "Created",
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "tags": [
+                {
+                  "code": "bap_terms",
+                  "list": [
+                    {
+                      "code": "accept_bpp_terms",
+                      "value": "Y"
+                    }
+                  ]
+                }
+              ],
+              "updated_at": "2025-04-24T18:02:50.646Z"
+            }
+          }
+        },
+        "response": {
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_confirm_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517770\",expires=\"1745521370\",headers=\"(created) (expires) digest\",signature=\"X/fLpEB85ZM0S7IVk1vewKoQNs76bLEAfG1Qh8YThlwCctj46udmv8obHQxZHTK0YChiO6dskBiXiPXkfUnbCw==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "f393797d-2d82-45ef-88ec-f419cb73f4ad",
+            "timestamp": "2025-04-24T18:02:50.694Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT10M",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "order": {
+              "state": "Accepted",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Pending"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "updated_at": "2025-04-24T18:02:50.694Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "f393797d-2d82-45ef-88ec-f419cb73f4ad",
+            "timestamp": "2025-04-24T18:02:50.694Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT10M",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517821\",expires=\"1745521421\",headers=\"(created) (expires) digest\",signature=\"pUsABhUXHN4npnQxV6ez+LJL4sXc5l793ZlPGPpMm+ADk7r+uk8vTVW1RXmhzwYsLoU32Tb0msKRO1E7cyZmAA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "c2c3e12c-16dd-4978-9007-a6a90feb6c02",
+            "timestamp": "2025-04-24T18:03:41.209Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT50S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "order": {
+              "state": "In-progress",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Agent-assigned"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "updated_at": "2025-04-24T18:03:41.209Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "c2c3e12c-16dd-4978-9007-a6a90feb6c02",
+            "timestamp": "2025-04-24T18:03:41.209Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT50S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "status_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|57eb646c-bfa8-46b3-9f55-f2c58e434dd4|ed25519\",algorithm=\"ed25519\",created=\"1745517866\",expires=\"1745547866769\",headers=\"(created) (expires) digest\",signature=\"HYkf5iQjmCWmZKi8VKMe6c/i+GyFRCdrxO6iQs07PE56K4tankVWGwSYtEbzgckCE47NvMAKZaEZjy+ksEkRCQ==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "status",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "a3df04d2-ac4a-4148-a947-b993e7eeb8f9",
+            "timestamp": "2025-04-24T18:04:26.769Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "order_id": "SS1745517638223"
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "status",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "a3df04d2-ac4a-4148-a947-b993e7eeb8f9",
+            "timestamp": "2025-04-24T18:04:26.769Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT30S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_2": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517868\",expires=\"1745521468\",headers=\"(created) (expires) digest\",signature=\"1MKrMms8g28KrgGzN60GdLk3bcfkNxYQz+h3jU3VPuxpapQzT6uVsHUIUc2CIeA06eU4aJ6DXI1222JmzploBA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "a3df04d2-ac4a-4148-a947-b993e7eeb8f9",
+            "timestamp": "2025-04-24T18:04:28.346Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT10M",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "order": {
+              "state": "In-progress",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Agent-assigned"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "updated_at": "2025-04-24T18:03:41.209Z"
+            }
+          }
+        },
+        "response": {}
+      },
+      "on_status_3": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517908\",expires=\"1745521508\",headers=\"(created) (expires) digest\",signature=\"IfPH1hBLEiYajqwSbPcPDaw7+nn3TDQZ1nQuzQzjrhaf8+rkdBYY+gkQL06RIUU2kq+0bbDwBA7UnX7+qJPlBA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "7998a4ec-cfa8-4fb7-8319-3823bddbe8af",
+            "timestamp": "2025-04-24T18:05:08.320Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT50S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "order": {
+              "state": "In-progress",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Out-for-delivery"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER"
+              },
+              "updated_at": "2025-04-24T18:05:08.320Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "7998a4ec-cfa8-4fb7-8319-3823bddbe8af",
+            "timestamp": "2025-04-24T18:05:08.320Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT50S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_4": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/seller|7518184f-f021-43e8-889b-a65298a33e4e|ed25519\",algorithm=\"ed25519\",created=\"1745517924\",expires=\"1745521524\",headers=\"(created) (expires) digest\",signature=\"PA7KPhaCqqVbu/pGOmokEpI8pQNZC97FxS7yUb7SR+dM9eNhdeYRp6mRWdyBMSLhLBqwpo8DkPDg8PRybAGuAA==\"",
+        "request": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "9ed254a1-7528-4c75-93dc-ef20ab9e9fb8",
+            "timestamp": "2025-04-24T18:05:24.755Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT50S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "order": {
+              "state": "Completed",
+              "provider": {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+              },
+              "items": [
+                {
+                  "id": "std_del",
+                  "category_id": "Standard Delivery",
+                  "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                  "descriptor": {
+                    "code": "P2P",
+                    "name": "Standard Delivery",
+                    "long_desc": "Upto 1 day for Delivery",
+                    "short_desc": "Upto 1 day for Delivery"
+                  },
+                  "time": {
+                    "label": "TAT",
+                    "duration": "P1D",
+                    "timestamp": "2025-04-25"
+                  }
+                }
+              ],
+              "billing": {
+                "name": "Lekhha_Seller_1",
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                },
+                "tax_number": "gstin1",
+                "phone": "9900025784",
+                "email": "Lekhha_Seller_1@email1.com",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-delivered"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "timestamp": "2025-04-24T18:05:24.755Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Delivery",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5204.12"
+                },
+                "breakup": [
+                  {
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "delivery"
+                  },
+                  {
+                    "title": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "@ondc/org/item_id": "std_del",
+                    "@ondc/org/title_type": "tax"
+                  }
+                ]
+              },
+              "payment": {
+                "collected_by": "BPP",
+                "type": "ON-ORDER",
+                "time": {
+                  "timestamp": "2025-04-24T18:05:24.755Z"
+                }
+              },
+              "updated_at": "2025-04-24T18:05:24.755Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+            "message_id": "9ed254a1-7528-4c75-93dc-ef20ab9e9fb8",
+            "timestamp": "2025-04-24T18:05:24.755Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "ttl": "PT50S",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      }
+    }
+  }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Downloaded_logs_Retail.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Downloaded_logs_Retail.json
@@ -1,0 +1,9426 @@
+{
+    "domain": "ONDC:RET10",
+    "payload": {
+      "search_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745517555\",expires=\"1745521155\",headers=\"(created) (expires) digest\",signature=\"svRWrDPefZaTnBOnY89dcOcJB5+U7gfUTkmstb2Mt2uSWQcgLNFl74QNbBb5zn8w6n3tH8WKQUFYx9Z75bdpDw==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "search",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "2b720846-83aa-4fbd-af77-a819833111c8",
+            "timestamp": "2025-04-24T17:59:15.243Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "intent": {
+              "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3"
+              },
+              "tags": [
+                {
+                  "code": "catalog_full",
+                  "list": [
+                    {
+                      "code": "payload_type",
+                      "value": "inline"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "action": "search",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "2b720846-83aa-4fbd-af77-a819833111c8",
+            "timestamp": "2025-04-24T17:59:15.364Z",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_search_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517559\",expires=\"1745547559368\",headers=\"(created) (expires) digest\",signature=\"sQeF2rSDHQoJogGP34TNYDdHaN/9TYg9fUXANleZTF74VXHFwLZkQsEcC7g6JIPoM6ojoFuiOYf11JEAshQuCQ==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "2b720846-83aa-4fbd-af77-a819833111c8",
+            "timestamp": "2025-04-24T17:59:19.361Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "catalog": {
+              "bpp/fulfillments": [
+                {
+                  "id": "1",
+                  "type": "Delivery",
+                  "contact": {
+                    "phone": "9900025784",
+                    "email": "sgupta.scm@gmail.com"
+                  }
+                }
+              ],
+              "bpp/descriptor": {
+                "name": "Lekhha",
+                "symbol": "https://lekhha.com/wp-content/uploads/2023/07/logo-light-1.png",
+                "short_desc": "App-based platform for order and inventory management.",
+                "long_desc": "LEKHHA is a simple solution to help you comprehensively run your business operations. Discover it to also track & manage your personal needs & resources. Reach out to us to serve you as your solution partner.",
+                "images": [
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/logo",
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/vendor",
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/consumer",
+                  "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/inventory"
+                ],
+                "tags": [
+                  {
+                    "code": "bpp_terms",
+                    "list": [
+                      {
+                        "code": "np_type",
+                        "value": "MSN"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "bpp/providers": [
+                {
+                  "id": "674ecb33d7b9e10f4210d972",
+                  "time": {
+                    "label": "enable",
+                    "timestamp": "2025-04-24T17:59:18.590Z"
+                  },
+                  "descriptor": {
+                    "name": "Lekhha Provider A",
+                    "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecb33d7b9e10f4210d972_S",
+                    "short_desc": "Lekhha_Seller_1 kyc short",
+                    "long_desc": "Lekhha_Seller_1 kyc long",
+                    "images": [
+                      "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecb33d7b9e10f4210d972"
+                    ]
+                  },
+                  "ttl": "P1D",
+                  "creds": [
+                    {
+                      "descriptor": {
+                        "code": "Lekhha_Seller_1_cred1",
+                        "name": "Lekhha_Seller_1 cred1",
+                        "short_desc": "Lekhha_Seller_1 cred1 short"
+                      },
+                      "id": "674ecbc6d7b9e10f4210d973_1",
+                      "tags": [
+                        {
+                          "code": "verification",
+                          "list": [
+                            {
+                              "code": "verify_url",
+                              "value": "https://url1url.com/verify1"
+                            },
+                            {
+                              "code": "valid_from",
+                              "value": "2024-12-09T00:00:00.000Z"
+                            },
+                            {
+                              "code": "valid_to",
+                              "value": "2027-03-31T00:00:00.000Z"
+                            }
+                          ]
+                        }
+                      ],
+                      "url": "https://url1url.com"
+                    }
+                  ],
+                  "fulfillments": [
+                    {
+                      "id": "1",
+                      "type": "Delivery",
+                      "contact": {
+                        "phone": "9900025784",
+                        "email": "sgupta.scm@gmail.com"
+                      }
+                    }
+                  ],
+                  "tags": [
+                    {
+                      "code": "order_value",
+                      "list": [
+                        {
+                          "code": "min_value",
+                          "value": "150.5"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "timing",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "Order"
+                        },
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "day_from",
+                          "value": "1"
+                        },
+                        {
+                          "code": "day_to",
+                          "value": "7"
+                        },
+                        {
+                          "code": "time_from",
+                          "value": "0001"
+                        },
+                        {
+                          "code": "time_to",
+                          "value": "2359"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "timing",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "Delivery"
+                        },
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "day_from",
+                          "value": "1"
+                        },
+                        {
+                          "code": "day_to",
+                          "value": "7"
+                        },
+                        {
+                          "code": "time_from",
+                          "value": "0001"
+                        },
+                        {
+                          "code": "time_to",
+                          "value": "2359"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "timing",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "Self-Pickup"
+                        },
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "day_from",
+                          "value": "1"
+                        },
+                        {
+                          "code": "day_to",
+                          "value": "7"
+                        },
+                        {
+                          "code": "time_from",
+                          "value": "0001"
+                        },
+                        {
+                          "code": "time_to",
+                          "value": "2359"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "serviceability",
+                      "list": [
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "category",
+                          "value": "Bakery, Cakes & Dairy"
+                        },
+                        {
+                          "code": "type",
+                          "value": "11"
+                        },
+                        {
+                          "code": "val",
+                          "value": "100000-999999"
+                        },
+                        {
+                          "code": "unit",
+                          "value": "pincode"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "serviceability",
+                      "list": [
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "category",
+                          "value": "Energy and Soft Drinks"
+                        },
+                        {
+                          "code": "type",
+                          "value": "11"
+                        },
+                        {
+                          "code": "val",
+                          "value": "100000-999999"
+                        },
+                        {
+                          "code": "unit",
+                          "value": "pincode"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "serviceability",
+                      "list": [
+                        {
+                          "code": "location",
+                          "value": "674ecbc6d7b9e10f4210d973"
+                        },
+                        {
+                          "code": "category",
+                          "value": "Fruits and Vegetables"
+                        },
+                        {
+                          "code": "type",
+                          "value": "11"
+                        },
+                        {
+                          "code": "val",
+                          "value": "100000-999999"
+                        },
+                        {
+                          "code": "unit",
+                          "value": "pincode"
+                        }
+                      ]
+                    }
+                  ],
+                  "items": [
+                    {
+                      "id": "676a61f6cac4860876a8e30f",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:59:18.859Z"
+                      },
+                      "parent_item_id": "V10000000001",
+                      "descriptor": {
+                        "name": "Milk orange",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk orange short",
+                        "long_desc": "Milk orange long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e3_0"
+                        ],
+                        "code": "1:1000000000232"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "13"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "49.82",
+                        "maximum_value": "53.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 11",
+                        "additives_info": "additives info 11",
+                        "brand_owner_FSSAI_license_no": "fssai license 11",
+                        "other_FSSAI_license_no": "other license 11",
+                        "importer_FSSAI_license_no": "importer license 11"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 11",
+                        "manufacturer_or_packer_address": "address 11",
+                        "common_or_generic_name_of_commodity": "commodity 11",
+                        "month_year_of_manufacture_packing_import": "year 11"
+                      }
+                    },
+                    {
+                      "id": "676a6179cac4860876a8e30b",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:59:18.887Z"
+                      },
+                      "parent_item_id": "V10000000002",
+                      "descriptor": {
+                        "name": "Milk blue",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk blue short",
+                        "long_desc": "Milk blue long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e5_0"
+                        ],
+                        "code": "1:1000000000233"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "10"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "12"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "380.00",
+                        "maximum_value": "400.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 9",
+                        "additives_info": "additives info 9",
+                        "brand_owner_FSSAI_license_no": "fssai license 9",
+                        "other_FSSAI_license_no": "other license 9",
+                        "importer_FSSAI_license_no": "importer license 9"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 9",
+                        "manufacturer_or_packer_address": "address 9",
+                        "common_or_generic_name_of_commodity": "commodity 9",
+                        "month_year_of_manufacture_packing_import": "year 9"
+                      }
+                    },
+                    {
+                      "id": "676a6260cac4860876a8e311",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:59:18.921Z"
+                      },
+                      "parent_item_id": "V10000000001",
+                      "descriptor": {
+                        "name": "Milk orange",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk orange short",
+                        "long_desc": "Milk orange long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e7_0"
+                        ],
+                        "code": "1:1000000000234"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "10"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "14"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "500.00",
+                        "maximum_value": "500.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 12",
+                        "additives_info": "additives info 12",
+                        "brand_owner_FSSAI_license_no": "fssai license 12",
+                        "other_FSSAI_license_no": "other license 12",
+                        "importer_FSSAI_license_no": "importer license 12"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 12",
+                        "manufacturer_or_packer_address": "address 12",
+                        "common_or_generic_name_of_commodity": "commodity 12",
+                        "month_year_of_manufacture_packing_import": "year 12"
+                      }
+                    },
+                    {
+                      "id": "676cf465e5eb3c28a8741e99",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:59:19.004Z"
+                      },
+                      "descriptor": {
+                        "name": "Pista milk",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Pista milk short",
+                        "long_desc": "Pista milk long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd72c_0"
+                        ],
+                        "code": "1:1000000000240"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "32"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "18.50",
+                        "maximum_value": "20.00"
+                      },
+                      "category_id": "Energy and Soft Drinks",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 18",
+                        "additives_info": "additives info 18",
+                        "brand_owner_FSSAI_license_no": "fssai license 18",
+                        "other_FSSAI_license_no": "other license 18",
+                        "importer_FSSAI_license_no": "importer license 18"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 18",
+                        "manufacturer_or_packer_address": "address 18",
+                        "common_or_generic_name_of_commodity": "commodity 18",
+                        "month_year_of_manufacture_packing_import": "year 18"
+                      }
+                    },
+                    {
+                      "id": "676cf465e5eb3c28a8741e9a",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:59:19.021Z"
+                      },
+                      "descriptor": {
+                        "name": "Mango milk",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Mango milk short",
+                        "long_desc": "Mango milk long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd72e_0"
+                        ],
+                        "code": "1:1000000000241"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "33"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "20.16",
+                        "maximum_value": "21.80"
+                      },
+                      "category_id": "Energy and Soft Drinks",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 7",
+                        "additives_info": "additives info 7",
+                        "brand_owner_FSSAI_license_no": "fssai license 7",
+                        "other_FSSAI_license_no": "other license 7",
+                        "importer_FSSAI_license_no": "importer license 7"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 7",
+                        "manufacturer_or_packer_address": "address 7",
+                        "common_or_generic_name_of_commodity": "commodity 7",
+                        "month_year_of_manufacture_packing_import": "year 7"
+                      }
+                    },
+                    {
+                      "id": "676cf465e5eb3c28a8741e9b",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:59:19.040Z"
+                      },
+                      "descriptor": {
+                        "name": "Vanilla milk",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Vanilla milk short",
+                        "long_desc": "Vanilla milk long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd730_0"
+                        ],
+                        "code": "1:1000000000242"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "35"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "18.51",
+                        "maximum_value": "20.01"
+                      },
+                      "category_id": "Energy and Soft Drinks",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 19",
+                        "additives_info": "additives info 19",
+                        "brand_owner_FSSAI_license_no": "fssai license 19",
+                        "other_FSSAI_license_no": "other license 19",
+                        "importer_FSSAI_license_no": "importer license 19"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer name 19",
+                        "manufacturer_or_packer_address": "packer address 19",
+                        "common_or_generic_name_of_commodity": "generic name 19",
+                        "month_year_of_manufacture_packing_import": "month year 19"
+                      }
+                    },
+                    {
+                      "id": "676a5f87cac4860876a8e2ff",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:59:19.057Z"
+                      },
+                      "descriptor": {
+                        "name": "Butter",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Butter short",
+                        "long_desc": "Butter long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd736_0"
+                        ],
+                        "code": "1:1000000000245"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "gram",
+                            "value": "200"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "23"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "109.38",
+                        "maximum_value": "124.30"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 3",
+                        "additives_info": "additives info 3",
+                        "brand_owner_FSSAI_license_no": "fssai license 3",
+                        "other_FSSAI_license_no": "other license 3",
+                        "importer_FSSAI_license_no": "importer license 3"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 13",
+                        "manufacturer_or_packer_address": "address 13",
+                        "common_or_generic_name_of_commodity": "commodity 13",
+                        "month_year_of_manufacture_packing_import": "year 13"
+                      }
+                    },
+                    {
+                      "id": "676a5f11cac4860876a8e2fb",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:59:19.073Z"
+                      },
+                      "descriptor": {
+                        "name": "Burfi",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Burfi short",
+                        "long_desc": "Burfi long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd73a_0"
+                        ],
+                        "code": "1:1000000000247"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "gram",
+                            "value": "200"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "22"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "71.20",
+                        "maximum_value": "80.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 2",
+                        "additives_info": "additives info 2",
+                        "brand_owner_FSSAI_license_no": "fssai license 2",
+                        "other_FSSAI_license_no": "other license 2",
+                        "importer_FSSAI_license_no": "importer license 2"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer name 2",
+                        "manufacturer_or_packer_address": "packer address 2",
+                        "common_or_generic_name_of_commodity": "commodity 2",
+                        "month_year_of_manufacture_packing_import": "packing import 2"
+                      }
+                    },
+                    {
+                      "id": "676aab3800d7d9212e3ba074",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:59:19.091Z"
+                      },
+                      "descriptor": {
+                        "name": "Watermelon",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Watermelon short",
+                        "long_desc": "Watermelon long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd740_0"
+                        ],
+                        "code": "1:2000000000349"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "46"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "45.00",
+                        "maximum_value": "45.00"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a9e1d00d7d9212e3b8f7f",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:59:19.107Z"
+                      },
+                      "descriptor": {
+                        "name": "Apple",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Apple short",
+                        "long_desc": "Apple long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd742_0"
+                        ],
+                        "code": "1:2000000000341"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "21"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "120.02",
+                        "maximum_value": "120.02"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676aaa5700d7d9212e3ba019",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:59:19.125Z"
+                      },
+                      "descriptor": {
+                        "name": "Papaya",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Papaya short",
+                        "long_desc": "Papaya long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd746_0"
+                        ],
+                        "code": "1:2000000000346"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "29"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "61.28",
+                        "maximum_value": "64.50"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a9fa200d7d9212e3b8fbd",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:59:19.139Z"
+                      },
+                      "descriptor": {
+                        "name": "Beetroot",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Beetroot short",
+                        "long_desc": "Beetroot long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6762dbb841c7aa7c86d1d1c2_0"
+                        ],
+                        "code": "1:2000000000343"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "0"
+                        },
+                        "maximum": {
+                          "count": "6"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "30.00",
+                        "maximum_value": "30.00"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a9f7800d7d9212e3b8fbb",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:59:19.155Z"
+                      },
+                      "descriptor": {
+                        "name": "Beans haricot",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Beans haricot short",
+                        "long_desc": "Beans haricot long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6762dbb841c7aa7c86d1d1c4_0"
+                        ],
+                        "code": "1:2000000000342"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "kilogram",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "0"
+                        },
+                        "maximum": {
+                          "count": "5"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "76.42",
+                        "maximum_value": "78.38"
+                      },
+                      "category_id": "Fruits and Vegetables",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M"
+                    },
+                    {
+                      "id": "676a6126cac4860876a8e309",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:59:19.235Z"
+                      },
+                      "parent_item_id": "V10000000002",
+                      "descriptor": {
+                        "name": "Milk blue",
+                        "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                        "short_desc": "Milk blue short",
+                        "long_desc": "Milk blue long",
+                        "images": [
+                          "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e1_0"
+                        ],
+                        "code": "1:1000000000231"
+                      },
+                      "quantity": {
+                        "unitized": {
+                          "measure": {
+                            "unit": "unit",
+                            "value": "1"
+                          }
+                        },
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "11"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00",
+                        "maximum_value": "40.00"
+                      },
+                      "category_id": "Bakery, Cakes & Dairy",
+                      "fulfillment_id": "1",
+                      "location_id": "674ecbc6d7b9e10f4210d973",
+                      "recommended": false,
+                      "@ondc/org/returnable": true,
+                      "@ondc/org/cancellable": true,
+                      "@ondc/org/seller_pickup_return": true,
+                      "@ondc/org/time_to_ship": "P0DT0H1M",
+                      "@ondc/org/available_on_cod": true,
+                      "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                      "tags": [
+                        {
+                          "code": "origin",
+                          "list": [
+                            {
+                              "code": "country",
+                              "value": "IND"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "veg_nonveg",
+                          "list": [
+                            {
+                              "code": "non_veg",
+                              "value": "yes"
+                            }
+                          ]
+                        }
+                      ],
+                      "@ondc/org/return_window": "P0DT1H1M",
+                      "@ondc/org/statutory_reqs_prepackaged_food": {
+                        "nutritional_info": "nutri info 8",
+                        "additives_info": "additives info 8",
+                        "brand_owner_FSSAI_license_no": "fssai license 8",
+                        "other_FSSAI_license_no": "other license 8",
+                        "importer_FSSAI_license_no": "importer license 8"
+                      },
+                      "@ondc/org/statutory_reqs_packaged_commodities": {
+                        "manufacturer_or_packer_name": "packer 8",
+                        "manufacturer_or_packer_address": "address 8",
+                        "common_or_generic_name_of_commodity": "commodity 8",
+                        "month_year_of_manufacture_packing_import": "year 8"
+                      }
+                    }
+                  ],
+                  "locations": [
+                    {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "time": {
+                        "label": "enable",
+                        "timestamp": "2025-04-24T17:59:18.592Z",
+                        "days": "1,2,3,4,5,6,7",
+                        "schedule": {
+                          "holidays": []
+                        },
+                        "range": {
+                          "start": "0001",
+                          "end": "2359"
+                        }
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "locality": "Bengaluru",
+                        "street": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "city": "Bengaluru",
+                        "area_code": "560103",
+                        "state": "KA"
+                      },
+                      "circle": {
+                        "gps": "12.9263841,77.6654374",
+                        "radius": {
+                          "unit": "km",
+                          "value": "999"
+                        }
+                      }
+                    }
+                  ],
+                  "categories": [
+                    {
+                      "id": "V10000000001",
+                      "descriptor": {
+                        "name": "Variant Group 10000000001"
+                      },
+                      "tags": [
+                        {
+                          "code": "type",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "variant_group"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "attr",
+                          "list": [
+                            {
+                              "code": "name",
+                              "value": "item.quantity.unitized.measure"
+                            },
+                            {
+                              "code": "seq",
+                              "value": "1"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "V10000000002",
+                      "descriptor": {
+                        "name": "Variant Group 10000000002"
+                      },
+                      "tags": [
+                        {
+                          "code": "type",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "variant_group"
+                            }
+                          ]
+                        },
+                        {
+                          "code": "attr",
+                          "list": [
+                            {
+                              "code": "name",
+                              "value": "item.quantity.unitized.measure"
+                            },
+                            {
+                              "code": "seq",
+                              "value": "1"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_search",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "2b720846-83aa-4fbd-af77-a819833111c8",
+            "timestamp": "2025-04-24T17:59:19.361Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            },
+            "tags": [
+              {
+                "code": "CATALOG_PROCESSING",
+                "list": [
+                  {
+                    "code": "MIN_PROCESS_DURATION",
+                    "value": "PT1S"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "select_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745517590\",expires=\"1745521190\",headers=\"(created) (expires) digest\",signature=\"kDM+VJb3xOMh2tHaqWfabrVSHFuniX/C3tYYzE1tsak1nT4rDjOGnq2xnsDwpqGw/cDcIptJxku2KbTGAi62BQ==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "select",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "286c6381-431d-4061-9148-2a35b871f258",
+            "timestamp": "2025-04-24T17:59:50.562Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  }
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                }
+              ],
+              "payment": {
+                "type": "ON-ORDER"
+              }
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "select",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "286c6381-431d-4061-9148-2a35b871f258",
+            "timestamp": "2025-04-24T17:59:50.702Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_select_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517598\",expires=\"1745547598736\",headers=\"(created) (expires) digest\",signature=\"JnBd05niylGyJJYm768E/EriF3Lsk9fGVr+6WlJXx7vqD72bqscyCJ+HJBUybMM53/S5FgXgseD1FY67y9fVDA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_select",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "286c6381-431d-4061-9148-2a35b871f258",
+            "timestamp": "2025-04-24T17:59:58.735Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "id": "676a6179cac4860876a8e30b",
+                  "quantity": {
+                    "count": 2
+                  }
+                },
+                {
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "id": "676a6126cac4860876a8e309",
+                  "quantity": {
+                    "count": 3
+                  }
+                }
+              ],
+              "fulfillments": [
+                {
+                  "id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "NS_LSP",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "PT55M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "NS_LSP",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "PT55M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a7c1748665475e6bf8d0c~19537~YAARI-19537-20250424-HUOK82QSOV~SY-1745517591277-41",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Ecom Express",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a7c1848665475e6bf8d0d~Delhivery~4d58548f-a563-4e12-8994-6687a504e8bf~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Delhivery",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P4D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Immediate Delivery",
+                  "@ondc/org/TAT": "PT60M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~37260627-31f5-461f-b01c-67c16a6b69b3",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Express Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~5476be14-c110-4772-a03b-8d28924827bc",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Next Day Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~ed4b869a-0023-4bcf-a533-a0536667b63f",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Same Day Delivery",
+                  "@ondc/org/TAT": "PT4H",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a7c1848665475e6bf8d11~MOVERDELIVERY~I1~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Mover",
+                  "tracking": false,
+                  "@ondc/org/category": "Immediate Delivery",
+                  "@ondc/org/TAT": "PT30M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a7c1848665475e6bf8d15~P1~I1~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Bharat Mart",
+                  "tracking": false,
+                  "@ondc/org/category": "Immediate Delivery",
+                  "@ondc/org/TAT": "PT60M",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a7c1948665475e6bf8d16~Bluedart Express~BDEEP0~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Bluedart Express",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P4D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a7c1948665475e6bf8d17~P1~I1~I1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "Exeed Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P8D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "680a7c1948665475e6bf8d18~DTDC~B2C SMART EXPRESS~1",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "DTDC",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P4D",
+                  "state": {
+                    "descriptor": {
+                      "code": "Serviceable"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "area_code": "122007"
+                      }
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "129654.47"
+                },
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "quantity": {
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "12"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "quantity": {
+                        "available": {
+                          "count": "99"
+                        },
+                        "maximum": {
+                          "count": "11"
+                        }
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "2.0"
+                    },
+                    "lsp_provider_id": "NS_LSP",
+                    "lsp_fulfillment_id": "ns_immediate_f1",
+                    "lsp_item_details": {
+                      "id": "ns_immediate",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "ns_immediate_f1",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "NS LSP Immediate Delivery",
+                        "short_desc": "Immediate Delivery by NS LSP",
+                        "long_desc": "Immediate Delivery by NS LSP"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "2.0"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT55M",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    },
+                    "lsp_provider_id": "NS_LSP",
+                    "lsp_fulfillment_id": "ns_immediate_f1-RTO",
+                    "lsp_item_details": {
+                      "id": "ns_immediate-RTO",
+                      "parent_item_id": "ns_immediate",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "ns_immediate_f1-RTO",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "RTO quote",
+                        "short_desc": "RTO quote",
+                        "long_desc": "RTO quote"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "0"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT55M",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1748665475e6bf8d0c~19537~YAARI-19537-20250424-HUOK82QSOV~SY-1745517591277-41",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "395.74"
+                    },
+                    "lsp_provider_id": "19537",
+                    "lsp_fulfillment_id": "SY-1745517591277-41",
+                    "lsp_item_details": {
+                      "id": "YAARI-19537-20250424-HUOK82QSOV",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "SY-1745517591277-41",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Ecom Express",
+                        "short_desc": "Ecom Express",
+                        "long_desc": "Ecom Express"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "395.74"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0d~Delhivery~4d58548f-a563-4e12-8994-6687a504e8bf~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "7500.72"
+                    },
+                    "lsp_provider_id": "Delhivery",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "4d58548f-a563-4e12-8994-6687a504e8bf",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "1",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Standard Delivery",
+                        "short_desc": "Delhivery Surface",
+                        "long_desc": "Delhivery Surface"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "7500.72"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P4D",
+                        "timestamp": "2025-04-28"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                    "lsp_item_details": {
+                      "id": "imd_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Immediate Delivery",
+                        "long_desc": "Upto 60 mins for Delivery",
+                        "short_desc": "Upto 60 mins for Delivery"
+                      },
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~37260627-31f5-461f-b01c-67c16a6b69b3",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "37260627-31f5-461f-b01c-67c16a6b69b3",
+                    "lsp_item_details": {
+                      "id": "exp_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Express Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Express Delivery",
+                      "fulfillment_id": "37260627-31f5-461f-b01c-67c16a6b69b3",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~5476be14-c110-4772-a03b-8d28924827bc",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "5476be14-c110-4772-a03b-8d28924827bc",
+                    "lsp_item_details": {
+                      "id": "nex_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Next Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Next Day Delivery",
+                      "fulfillment_id": "5476be14-c110-4772-a03b-8d28924827bc",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~ed4b869a-0023-4bcf-a533-a0536667b63f",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "ed4b869a-0023-4bcf-a533-a0536667b63f",
+                    "lsp_item_details": {
+                      "id": "same_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Same Day Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Same Day Delivery",
+                      "fulfillment_id": "ed4b869a-0023-4bcf-a533-a0536667b63f",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT4H",
+                        "timestamp": "2025-04-24"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d11~MOVERDELIVERY~I1~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "25527"
+                    },
+                    "lsp_provider_id": "MOVERDELIVERY",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "I1",
+                      "parent_item_id": "",
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "1",
+                      "descriptor": {
+                        "name": "30 min delivery",
+                        "short_desc": "30 min delivery for F&B",
+                        "long_desc": "30 min delivery for F&B",
+                        "code": "P2P"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "25527"
+                      },
+                      "time": {
+                        "duration": "PT30M",
+                        "label": "TAT",
+                        "timestamp": "2025-04-24T17:59:51.9839819Z"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d15~P1~I1~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "59.00"
+                    },
+                    "lsp_provider_id": "P1",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "I1",
+                      "parent_item_id": "",
+                      "category_id": "Immediate Delivery",
+                      "fulfillment_id": "1",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "60 min delivery",
+                        "short_desc": "60 min delivery for F&B",
+                        "long_desc": "60 min delivery for F&B"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "59.00"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "PT60M",
+                        "timestamp": "2023-06-06"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1948665475e6bf8d16~Bluedart Express~BDEEP0~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "1388.29"
+                    },
+                    "lsp_provider_id": "Bluedart Express",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "BDEEP0",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "1",
+                      "descriptor": {
+                        "name": "Dart Surface Etail",
+                        "code": "P2H2P",
+                        "short_desc": "Standard Delivery",
+                        "long_desc": "Standard Delivery"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "timestamp": "2025-04-28",
+                        "duration": "P4D"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "1388.29"
+                      },
+                      "parent_item_id": ""
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1948665475e6bf8d17~P1~I1~I1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "65560.00"
+                    },
+                    "lsp_provider_id": "P1",
+                    "lsp_fulfillment_id": "I1",
+                    "lsp_item_details": {
+                      "id": "I1",
+                      "parent_item_id": "",
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "I1",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Standard",
+                        "short_desc": "Standard",
+                        "long_desc": "Standard"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "65560.00"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P8D",
+                        "timestamp": "2025-04-24T17:59:53.494904Z"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1948665475e6bf8d18~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "815.00"
+                    },
+                    "lsp_provider_id": "DTDC",
+                    "lsp_fulfillment_id": "1",
+                    "lsp_item_details": {
+                      "id": "B2C SMART EXPRESS",
+                      "category_id": "Standard Delivery",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2H2P",
+                        "name": "Standard Delivery",
+                        "short_desc": "B2C SMART EXPRESS",
+                        "long_desc": "3 - 4 Day/s"
+                      },
+                      "price": {
+                        "currency": "INR",
+                        "value": "815.00"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P4D",
+                        "timestamp": "2025-04-28"
+                      },
+                      "fulfillment_id": "1"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate~ns_immediate_f1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1748665475e6bf8d0c~19537~YAARI-19537-20250424-HUOK82QSOV~SY-1745517591277-41",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1748665475e6bf8d0c~19537~YAARI-19537-20250424-HUOK82QSOV~SY-1745517591277-41",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1748665475e6bf8d0c~19537~YAARI-19537-20250424-HUOK82QSOV~SY-1745517591277-41",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0d~Delhivery~4d58548f-a563-4e12-8994-6687a504e8bf~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0d~Delhivery~4d58548f-a563-4e12-8994-6687a504e8bf~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0d~Delhivery~4d58548f-a563-4e12-8994-6687a504e8bf~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~37260627-31f5-461f-b01c-67c16a6b69b3",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~37260627-31f5-461f-b01c-67c16a6b69b3",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~37260627-31f5-461f-b01c-67c16a6b69b3",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~5476be14-c110-4772-a03b-8d28924827bc",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~5476be14-c110-4772-a03b-8d28924827bc",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~5476be14-c110-4772-a03b-8d28924827bc",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~ed4b869a-0023-4bcf-a533-a0536667b63f",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~ed4b869a-0023-4bcf-a533-a0536667b63f",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~ed4b869a-0023-4bcf-a533-a0536667b63f",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d11~MOVERDELIVERY~I1~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d11~MOVERDELIVERY~I1~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d11~MOVERDELIVERY~I1~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d15~P1~I1~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d15~P1~I1~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d15~P1~I1~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1948665475e6bf8d16~Bluedart Express~BDEEP0~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1948665475e6bf8d16~Bluedart Express~BDEEP0~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1948665475e6bf8d16~Bluedart Express~BDEEP0~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1948665475e6bf8d17~P1~I1~I1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1948665475e6bf8d17~P1~I1~I1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1948665475e6bf8d17~P1~I1~I1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1948665475e6bf8d18~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1948665475e6bf8d18~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1948665475e6bf8d18~DTDC~B2C SMART EXPRESS~1",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "ttl": "P1D"
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "accept_bap_terms",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_select",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "286c6381-431d-4061-9148-2a35b871f258",
+            "timestamp": "2025-04-24T17:59:58.735Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "init_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745517622\",expires=\"1745521222\",headers=\"(created) (expires) digest\",signature=\"rCK9b3k/5XgusUQ10wBFP+mC8imS8gXBDoWStwNGefM1pgI/v+nBolhL47esCCIxDlegM+CoPI9xpwJtvx58Cg==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "1d449241-9b55-4783-a015-d5d16ae1cf8a",
+            "timestamp": "2025-04-24T18:00:22.623Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "ttl": "PT30S",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "nic2004:60232",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "init",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "d33c7a24-7cbc-4b85-8f6d-6807019414ae",
+            "timestamp": "2025-04-24T18:00:22.865Z",
+            "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+            "bap_id": "stageapi.lekhha.com",
+            "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+            "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_init_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517625\",expires=\"1745547625863\",headers=\"(created) (expires) digest\",signature=\"gZpoDaWPTKdBgSNmCq89DyqTbWEJFK1V1uttympPZV7PQqzTKoW6MmW7YIzxs2dGA5KnFRhmcZrS05oZmAsiCQ==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "1d449241-9b55-4783-a015-d5d16ae1cf8a",
+            "timestamp": "2025-04-24T18:00:25.856Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "currency": "INR",
+                  "amount": "0"
+                },
+                "status": "NOT-PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "return_window_expiry",
+                "@ondc/org/settlement_window": "P2D",
+                "@ondc/org/withholding_amount": "0",
+                "@ondc/org/collected_by_status": "Assert",
+                "collected_by": "BPP"
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_init",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "1d449241-9b55-4783-a015-d5d16ae1cf8a",
+            "timestamp": "2025-04-24T18:00:25.856Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "confirm_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745517638\",expires=\"1745521238\",headers=\"(created) (expires) digest\",signature=\"7R58MsDTxCAFrFAGGeEXLYRDP3HtV21heUNSVc2BgDdovlKHlVg/z5RrVfmirpcShiur5fgbYmDGB/pZTu2xAA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "confirm",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "b7d08080-fa7e-4479-a5a3-6e12e19b7820",
+            "timestamp": "2025-04-24T18:00:38.223Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "Created",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1 legal"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "person": {
+                      "name": "Nirdosh Chauhan"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                },
+                {
+                  "code": "bap_terms",
+                  "list": [
+                    {
+                      "code": "tax_number",
+                      "value": "00XYZAB1234C1Z8"
+                    },
+                    {
+                      "code": "accept_bpp_terms",
+                      "value": "Y"
+                    }
+                  ]
+                }
+              ],
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Assert",
+                "collected_by": "BAP"
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:00:38.223Z"
+            }
+          }
+        },
+        "response": {
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_confirm_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517643\",expires=\"1745547643705\",headers=\"(created) (expires) digest\",signature=\"/gKMgSfiR7S+ewTNPIaXsZ4GXkglaCAMgsJt5l6oRSFlTMuhhhtdKVCPotFc8fXiWhZuN0cAFfQ363JCQdjCAg==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "b7d08080-fa7e-4479-a5a3-6e12e19b7820",
+            "timestamp": "2025-04-24T18:00:43.697Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "Created",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T17:30:00.000Z",
+                        "end": "2025-04-24T19:30:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code",
+                      "long_desc": ""
+                    },
+                    "time": {
+                      "range": {
+                        "end": "2025-04-24T18:03:43.679Z"
+                      }
+                    }
+                  },
+                  "state": {
+                    "descriptor": {
+                      "code": "Pending",
+                      "name": "Getting ready for shipment (packaging)"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    },
+                    {
+                      "code": "collect_payment",
+                      "value": "Y"
+                    },
+                    {
+                      "code": "max_liability",
+                      "value": "2"
+                    },
+                    {
+                      "code": "max_liability_cap",
+                      "value": "10000"
+                    },
+                    {
+                      "code": "mandatory_arbitration",
+                      "value": "false"
+                    },
+                    {
+                      "code": "court_jurisdiction",
+                      "value": "Bengaluru"
+                    },
+                    {
+                      "code": "delay_interest",
+                      "value": "7"
+                    },
+                    {
+                      "code": "tax_number",
+                      "value": "29ABGCS7802J1ZX"
+                    },
+                    {
+                      "code": "provider_tax_number",
+                      "value": "ABGCS7802J"
+                    }
+                  ]
+                },
+                {
+                  "code": "bap_terms",
+                  "list": [
+                    {
+                      "code": "tax_number",
+                      "value": "00XYZAB1234C1Z8"
+                    },
+                    {
+                      "code": "accept_bpp_terms",
+                      "value": "Y"
+                    }
+                  ]
+                }
+              ],
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Assert",
+                "collected_by": "BAP"
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:00:43.697Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_confirm",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "b7d08080-fa7e-4479-a5a3-6e12e19b7820",
+            "timestamp": "2025-04-24T18:00:43.697Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517667\",expires=\"1745547667347\",headers=\"(created) (expires) digest\",signature=\"JDO5ZdXoJDW6VlpgXaY8gTPLS/O77pQETVmfhIkFPt2Oc4EcQZWJgWLKKTvXqXFejmOMopGGy7blqmA9C4uADw==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "91810c78-abe5-4af3-ad38-6297d126c28f",
+            "timestamp": "2025-04-24T18:01:07.326Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "Accepted",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "tracking": false,
+                  "@ondc/org/category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D",
+                  "start": {
+                    "location": {
+                      "id": "674ecbc6d7b9e10f4210d973",
+                      "descriptor": {
+                        "name": "Lekhha_Seller_1"
+                      },
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "street": "",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code",
+                      "long_desc": "Pls pickup orders from counter number 01."
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-24T17:30:00.000Z",
+                        "end": "2025-04-24T19:30:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code",
+                      "long_desc": ""
+                    },
+                    "time": {
+                      "range": {
+                        "end": "2025-04-24T18:03:43.679Z"
+                      }
+                    }
+                  },
+                  "state": {
+                    "descriptor": {
+                      "code": "Pending",
+                      "name": "Getting ready for shipment (packaging)"
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:01:07.264Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "91810c78-abe5-4af3-ad38-6297d126c28f",
+            "timestamp": "2025-04-24T18:01:07.326Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_2": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517680\",expires=\"1745547680451\",headers=\"(created) (expires) digest\",signature=\"vhGTLALsIgbxXwaO5kaWPviDVWN029Fybe0ulEvT5/0xPoaF0Y+ayMhHckLOcLO61A2mzMzmjvB7m4F5t6OuBQ==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "409d3e03-bb03-4842-bcfb-504c8ed74458",
+            "timestamp": "2025-04-24T18:01:20.442Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Packed",
+                      "name": "Packaging completed. Ready to ship"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:01:07.264Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "409d3e03-bb03-4842-bcfb-504c8ed74458",
+            "timestamp": "2025-04-24T18:01:20.442Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_3": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517689\",expires=\"1745547689633\",headers=\"(created) (expires) digest\",signature=\"t/l9RYcGMTx/sHXChzV7iZSA68qompG/CMgE710u6cSPUmfS8hDrqdBOXKvfumAL4CQXvTthTQGtjizIgm3bDg==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "1789f17a-cba4-4634-821b-8c7172fb80ea",
+            "timestamp": "2025-04-24T18:01:29.626Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Agent-assigned",
+                      "name": "Agent assigned"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      }
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:01:07.264Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "1789f17a-cba4-4634-821b-8c7172fb80ea",
+            "timestamp": "2025-04-24T18:01:29.626Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_4": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517695\",expires=\"1745547695764\",headers=\"(created) (expires) digest\",signature=\"DQwsYcL4UMWLRQGPVVNOArlAqxf/+DMgahtoWDgHm8i3on8cilvv3em9zLx6nklarwRoI495BCza0x7FY9CGDw==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "9a043075-de5e-4542-8101-713f535b4a70",
+            "timestamp": "2025-04-24T18:01:35.757Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-picked-up",
+                      "name": "Product picked up from the source and shipment started"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:01:35.578Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:01:07.264Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "9a043075-de5e-4542-8101-713f535b4a70",
+            "timestamp": "2025-04-24T18:01:35.757Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_5": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517701\",expires=\"1745547701766\",headers=\"(created) (expires) digest\",signature=\"pS9IHJRrWCSZnTjHSTNstMvUh0BwOoPIkWsLYxCvsx2Dq3MXDIuFHiBBP7Ji6L1izCdoTSfwfXvXJI9PVKjTDA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "ab702c07-22ba-4b74-b870-2c63e38e22ed",
+            "timestamp": "2025-04-24T18:01:41.759Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Out-for-delivery",
+                      "name": "Product would be delivered soon"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:01:35.578Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:01:07.264Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "ab702c07-22ba-4b74-b870-2c63e38e22ed",
+            "timestamp": "2025-04-24T18:01:41.759Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_6": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517729\",expires=\"1745547729215\",headers=\"(created) (expires) digest\",signature=\"QuG+g+kdMnus2Sl/m7d5cbBfi2mZshXabUbG7HO/PIpPvEFmBp9PUq62CpVHMdmHHciLqqop0VcvBmzx4KcWAA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "202480a7-a343-403f-8d50-0e527bd9f4ba",
+            "timestamp": "2025-04-24T18:02:09.208Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "In-progress",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Out-for-delivery",
+                      "name": "Product would be delivered soon"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:01:35.578Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      }
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:01:07.264Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "202480a7-a343-403f-8d50-0e527bd9f4ba",
+            "timestamp": "2025-04-24T18:02:09.208Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_status_7": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517743\",expires=\"1745547743645\",headers=\"(created) (expires) digest\",signature=\"ICSplrkdMUrjp3MQouI3R/xpxvzY+pIFPWwhkT9SpFHYOMtFw6JJ/rjkd+7ogV84JZl+p9ToET2nAl7N/HxWDg==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "eeb2c0b9-d0e8-4241-bc00-d117355a0646",
+            "timestamp": "2025-04-24T18:02:23.636Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "Completed",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-delivered",
+                      "name": "Product delivered"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:01:35.578Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:02:23.474Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Delivery",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:01:07.264Z"
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_status",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "eeb2c0b9-d0e8-4241-bc00-d117355a0646",
+            "timestamp": "2025-04-24T18:02:23.636Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "update_1": {
+        "signature": "Signature keyId=\"pramaan.ondc.org/beta/preprod/mock/buyer|df0b5672-27f0-42c4-90b5-9138e3c45a79|ed25519\",algorithm=\"ed25519\",created=\"1745517760\",expires=\"1745521360\",headers=\"(created) (expires) digest\",signature=\"E9UsoMi7BpMKmPhD157g2Lxfdxo0YvWckvFfWta2NP57p1uXP6ZgoPq9GDwexMhw10lSouyRp/ixUuDZ0IBuBQ==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "update",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "b700e0f6-b2e7-4eae-8bbe-55c91b27cc2d",
+            "timestamp": "2025-04-24T18:02:40.815Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+            "ttl": "PT30S"
+          },
+          "message": {
+            "update_target": "item",
+            "order": {
+              "id": "SS1745517638223",
+              "fulfillments": [
+                {
+                  "type": "Return",
+                  "tags": [
+                    {
+                      "code": "return_request",
+                      "list": [
+                        {
+                          "code": "id",
+                          "value": "ce69a8d9-e7b9-4f64-8879-8dffe2783019"
+                        },
+                        {
+                          "code": "item_id",
+                          "value": "676a6179cac4860876a8e30b"
+                        },
+                        {
+                          "code": "item_quantity",
+                          "value": "2"
+                        },
+                        {
+                          "code": "reason_id",
+                          "value": "003"
+                        },
+                        {
+                          "code": "reason_desc",
+                          "value": "some detailed reason for return"
+                        },
+                        {
+                          "code": "images",
+                          "value": "https://some-images-for-item.com"
+                        },
+                        {
+                          "code": "ttl_approval",
+                          "value": "PT24H"
+                        },
+                        {
+                          "code": "ttl_reverseqc",
+                          "value": "P3D"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "return_request",
+                      "list": [
+                        {
+                          "code": "id",
+                          "value": "9f4b8ecb-8389-4034-98f1-f371436e1e4e"
+                        },
+                        {
+                          "code": "item_id",
+                          "value": "676a6126cac4860876a8e309"
+                        },
+                        {
+                          "code": "item_quantity",
+                          "value": "3"
+                        },
+                        {
+                          "code": "reason_id",
+                          "value": "003"
+                        },
+                        {
+                          "code": "reason_desc",
+                          "value": "some detailed reason for return"
+                        },
+                        {
+                          "code": "images",
+                          "value": "https://some-images-for-item.com"
+                        },
+                        {
+                          "code": "ttl_approval",
+                          "value": "PT24H"
+                        },
+                        {
+                          "code": "ttl_reverseqc",
+                          "value": "P3D"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "update",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "b700e0f6-b2e7-4eae-8bbe-55c91b27cc2d",
+            "timestamp": "2025-04-24T18:02:40.856Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_update_1": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517772\",expires=\"1745547772769\",headers=\"(created) (expires) digest\",signature=\"hP+uh+hYwtFPFQoYhvoIOt1TdYlxqKS1XdctheVizmanDx8vIeMwAvQdWbhCIjyVB6IBT8dPua0Z5/qw9ATqBw==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_update",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "b700e0f6-b2e7-4eae-8bbe-55c91b27cc2d",
+            "timestamp": "2025-04-24T18:02:52.757Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "Completed",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-delivered",
+                      "name": "Product delivered"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:01:35.578Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:02:23.474Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Delivery",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                },
+                {
+                  "id": "ce69a8d9-e7b9-4f64-8879-8dffe2783019",
+                  "type": "Return",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "state": {
+                    "descriptor": {
+                      "code": "Return_Initiated",
+                      "name": "Return request is received"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "return_request",
+                      "list": [
+                        {
+                          "code": "id",
+                          "value": "ce69a8d9-e7b9-4f64-8879-8dffe2783019"
+                        },
+                        {
+                          "code": "item_id",
+                          "value": "676a6179cac4860876a8e30b"
+                        },
+                        {
+                          "code": "item_quantity",
+                          "value": "2"
+                        },
+                        {
+                          "code": "reason_id",
+                          "value": "003"
+                        },
+                        {
+                          "code": "reason_desc",
+                          "value": "some detailed reason for return"
+                        },
+                        {
+                          "code": "images",
+                          "value": "https://some-images-for-item.com"
+                        },
+                        {
+                          "code": "ttl_approval",
+                          "value": "PT24H"
+                        },
+                        {
+                          "code": "ttl_reverseqc",
+                          "value": "P3D"
+                        },
+                        {
+                          "code": "initiated_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                        }
+                      ]
+                    }
+                  ],
+                  "category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D"
+                },
+                {
+                  "id": "9f4b8ecb-8389-4034-98f1-f371436e1e4e",
+                  "type": "Return",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "state": {
+                    "descriptor": {
+                      "code": "Return_Initiated",
+                      "name": "Return request is received"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": "other pickup confirmation code"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "return_request",
+                      "list": [
+                        {
+                          "code": "id",
+                          "value": "9f4b8ecb-8389-4034-98f1-f371436e1e4e"
+                        },
+                        {
+                          "code": "item_id",
+                          "value": "676a6126cac4860876a8e309"
+                        },
+                        {
+                          "code": "item_quantity",
+                          "value": "3"
+                        },
+                        {
+                          "code": "reason_id",
+                          "value": "003"
+                        },
+                        {
+                          "code": "reason_desc",
+                          "value": "some detailed reason for return"
+                        },
+                        {
+                          "code": "images",
+                          "value": "https://some-images-for-item.com"
+                        },
+                        {
+                          "code": "ttl_approval",
+                          "value": "PT24H"
+                        },
+                        {
+                          "code": "ttl_reverseqc",
+                          "value": "P3D"
+                        },
+                        {
+                          "code": "initiated_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                        }
+                      ]
+                    }
+                  ],
+                  "category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D"
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:02:52.757Z",
+              "documents": [
+                {
+                  "url": "https://stageapi.lekhha.com/Misc/Invoice/productImages/680a7c3948665475e6bf8d27.pdf",
+                  "label": "Invoice"
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_update",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "b700e0f6-b2e7-4eae-8bbe-55c91b27cc2d",
+            "timestamp": "2025-04-24T18:02:52.757Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_update_2": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517821\",expires=\"1745547821604\",headers=\"(created) (expires) digest\",signature=\"h1s2psey+ImiQktkMGGZig3oQBadadfFkHiRH7oVAXgtbRuHntncLPOyT8uDN4emzoXLnnNaIXBm4B18RCHQAA==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_update",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "6609982d-25c4-45b3-aa0e-09d66d30187b",
+            "timestamp": "2025-04-24T18:03:41.586Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "Completed",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 2
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 3
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-delivered",
+                      "name": "Product delivered"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:01:35.578Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:02:23.474Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Delivery",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                },
+                {
+                  "id": "ce69a8d9-e7b9-4f64-8879-8dffe2783019",
+                  "type": "Return",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "state": {
+                    "descriptor": {
+                      "code": "Return_Approved",
+                      "name": "Return request approved"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": ""
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "return_request",
+                      "list": [
+                        {
+                          "code": "id",
+                          "value": "ce69a8d9-e7b9-4f64-8879-8dffe2783019"
+                        },
+                        {
+                          "code": "item_id",
+                          "value": "676a6179cac4860876a8e30b"
+                        },
+                        {
+                          "code": "item_quantity",
+                          "value": "2"
+                        },
+                        {
+                          "code": "reason_id",
+                          "value": "003"
+                        },
+                        {
+                          "code": "reason_desc",
+                          "value": "some detailed reason for return"
+                        },
+                        {
+                          "code": "images",
+                          "value": "https://some-images-for-item.com"
+                        },
+                        {
+                          "code": "ttl_approval",
+                          "value": "PT24H"
+                        },
+                        {
+                          "code": "ttl_reverseqc",
+                          "value": "P3D"
+                        },
+                        {
+                          "code": "initiated_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                        }
+                      ]
+                    }
+                  ],
+                  "category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D"
+                },
+                {
+                  "id": "9f4b8ecb-8389-4034-98f1-f371436e1e4e",
+                  "type": "Return",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "state": {
+                    "descriptor": {
+                      "code": "Return_Approved",
+                      "name": "Return request approved"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": ""
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "return_request",
+                      "list": [
+                        {
+                          "code": "id",
+                          "value": "9f4b8ecb-8389-4034-98f1-f371436e1e4e"
+                        },
+                        {
+                          "code": "item_id",
+                          "value": "676a6126cac4860876a8e309"
+                        },
+                        {
+                          "code": "item_quantity",
+                          "value": "3"
+                        },
+                        {
+                          "code": "reason_id",
+                          "value": "003"
+                        },
+                        {
+                          "code": "reason_desc",
+                          "value": "some detailed reason for return"
+                        },
+                        {
+                          "code": "images",
+                          "value": "https://some-images-for-item.com"
+                        },
+                        {
+                          "code": "ttl_approval",
+                          "value": "PT24H"
+                        },
+                        {
+                          "code": "ttl_reverseqc",
+                          "value": "P3D"
+                        },
+                        {
+                          "code": "initiated_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                        }
+                      ]
+                    }
+                  ],
+                  "category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D"
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "6191.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 2
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "800.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "-40.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 3
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:03:41.586Z",
+              "documents": [
+                {
+                  "url": "https://stageapi.lekhha.com/Misc/Invoice/productImages/680a7c3948665475e6bf8d27.pdf",
+                  "label": "Invoice"
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_update",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "6609982d-25c4-45b3-aa0e-09d66d30187b",
+            "timestamp": "2025-04-24T18:03:41.586Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_update_3": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517908\",expires=\"1745547908561\",headers=\"(created) (expires) digest\",signature=\"MAXW0Khn66hwFrGecl2t7XYRxApeDXg/b6xkeQO1qq8YTWTt+yGDdb8Cf5m8gW24MNgHBWFfNpIhZNK+lqyYBw==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_update",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "479b8276-9aab-4da1-afe9-8ea30cee538f",
+            "timestamp": "2025-04-24T18:05:08.542Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "Completed",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 0
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 0
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "fulfillment_id": "ce69a8d9-e7b9-4f64-8879-8dffe2783019",
+                  "quantity": {
+                    "count": 2
+                  }
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "fulfillment_id": "9f4b8ecb-8389-4034-98f1-f371436e1e4e",
+                  "quantity": {
+                    "count": 3
+                  }
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-delivered",
+                      "name": "Product delivered"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:01:35.578Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:02:23.474Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Delivery",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                },
+                {
+                  "id": "ce69a8d9-e7b9-4f64-8879-8dffe2783019",
+                  "type": "Return",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "state": {
+                    "descriptor": {
+                      "code": "Return_Picked",
+                      "name": "Reverse QC is initiated"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": ""
+                    },
+                    "time": {
+                      "timestamp": "2025-04-24T18:05:08.511Z"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "return_request",
+                      "list": [
+                        {
+                          "code": "id",
+                          "value": "ce69a8d9-e7b9-4f64-8879-8dffe2783019"
+                        },
+                        {
+                          "code": "item_id",
+                          "value": "676a6179cac4860876a8e30b"
+                        },
+                        {
+                          "code": "item_quantity",
+                          "value": "2"
+                        },
+                        {
+                          "code": "reason_id",
+                          "value": "003"
+                        },
+                        {
+                          "code": "reason_desc",
+                          "value": "some detailed reason for return"
+                        },
+                        {
+                          "code": "images",
+                          "value": "https://some-images-for-item.com"
+                        },
+                        {
+                          "code": "ttl_approval",
+                          "value": "PT24H"
+                        },
+                        {
+                          "code": "ttl_reverseqc",
+                          "value": "P3D"
+                        },
+                        {
+                          "code": "initiated_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "quote_trail",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "item"
+                        },
+                        {
+                          "code": "id",
+                          "value": "676a6179cac4860876a8e30b"
+                        },
+                        {
+                          "code": "currency",
+                          "value": "INR"
+                        },
+                        {
+                          "code": "value",
+                          "value": "-800.00"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "quote_trail",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "discount"
+                        },
+                        {
+                          "code": "id",
+                          "value": "676a6179cac4860876a8e30b"
+                        },
+                        {
+                          "code": "currency",
+                          "value": "INR"
+                        },
+                        {
+                          "code": "value",
+                          "value": "40.00"
+                        }
+                      ]
+                    }
+                  ],
+                  "category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D"
+                },
+                {
+                  "id": "9f4b8ecb-8389-4034-98f1-f371436e1e4e",
+                  "type": "Return",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "state": {
+                    "descriptor": {
+                      "code": "Return_Picked",
+                      "name": "Reverse QC is initiated"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": ""
+                    },
+                    "time": {
+                      "timestamp": "2025-04-24T18:05:08.531Z"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "return_request",
+                      "list": [
+                        {
+                          "code": "id",
+                          "value": "9f4b8ecb-8389-4034-98f1-f371436e1e4e"
+                        },
+                        {
+                          "code": "item_id",
+                          "value": "676a6126cac4860876a8e309"
+                        },
+                        {
+                          "code": "item_quantity",
+                          "value": "3"
+                        },
+                        {
+                          "code": "reason_id",
+                          "value": "003"
+                        },
+                        {
+                          "code": "reason_desc",
+                          "value": "some detailed reason for return"
+                        },
+                        {
+                          "code": "images",
+                          "value": "https://some-images-for-item.com"
+                        },
+                        {
+                          "code": "ttl_approval",
+                          "value": "PT24H"
+                        },
+                        {
+                          "code": "ttl_reverseqc",
+                          "value": "P3D"
+                        },
+                        {
+                          "code": "initiated_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "quote_trail",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "item"
+                        },
+                        {
+                          "code": "id",
+                          "value": "676a6126cac4860876a8e309"
+                        },
+                        {
+                          "code": "currency",
+                          "value": "INR"
+                        },
+                        {
+                          "code": "value",
+                          "value": "-120.00"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "quote_trail",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "discount"
+                        },
+                        {
+                          "code": "id",
+                          "value": "676a6126cac4860876a8e309"
+                        },
+                        {
+                          "code": "currency",
+                          "value": "INR"
+                        },
+                        {
+                          "code": "value",
+                          "value": "0.00"
+                        }
+                      ]
+                    }
+                  ],
+                  "category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D"
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5311.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 0
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 0
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:05:08.542Z",
+              "documents": [
+                {
+                  "url": "https://stageapi.lekhha.com/Misc/Invoice/productImages/680a7c3948665475e6bf8d27.pdf",
+                  "label": "Invoice"
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_update",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "479b8276-9aab-4da1-afe9-8ea30cee538f",
+            "timestamp": "2025-04-24T18:05:08.542Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      },
+      "on_update_4": {
+        "signature": "Signature keyId=\"stageapi.lekhha.com|674ecb33d7b9e10f4210d972|ed25519\",algorithm=\"ed25519\",created=\"1745517925\",expires=\"1745547925003\",headers=\"(created) (expires) digest\",signature=\"r7x6rcqBvGPt3jxLd/DBxhaZYA4rXZAPAmWnlJfMXZSyQGXZEHCLhqeSoR3wEf1yxqqY7oTGBG1qlAYIurZRCw==\"",
+        "request": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_update",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "f7374856-d520-4258-9429-487b11f5ec5c",
+            "timestamp": "2025-04-24T18:05:24.980Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "order": {
+              "id": "SS1745517638223",
+              "state": "Completed",
+              "provider": {
+                "id": "674ecb33d7b9e10f4210d972",
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973"
+                  }
+                ]
+              },
+              "items": [
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 0
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "location_id": "674ecbc6d7b9e10f4210d973",
+                  "quantity": {
+                    "count": 0
+                  },
+                  "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+                },
+                {
+                  "id": "676a6179cac4860876a8e30b",
+                  "fulfillment_id": "ce69a8d9-e7b9-4f64-8879-8dffe2783019",
+                  "quantity": {
+                    "count": 2
+                  }
+                },
+                {
+                  "id": "676a6126cac4860876a8e309",
+                  "fulfillment_id": "9f4b8ecb-8389-4034-98f1-f371436e1e4e",
+                  "quantity": {
+                    "count": 3
+                  }
+                }
+              ],
+              "billing": {
+                "address": {
+                  "name": "Nirdosh Chauhan",
+                  "building": "221 B",
+                  "locality": "Baker Steeet",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "country": "India",
+                  "area_code": "122007"
+                },
+                "tax_number": "00ABCDE1234F1Z5",
+                "name": "Nirdosh Chauhan",
+                "email": "nirdosh.chauhan@sequelstring.com",
+                "phone": "9876543210",
+                "created_at": "2025-04-24T18:00:22.623Z",
+                "updated_at": "2025-04-24T18:00:22.623Z"
+              },
+              "fulfillments": [
+                {
+                  "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "type": "Delivery",
+                  "state": {
+                    "descriptor": {
+                      "code": "Order-delivered",
+                      "name": "Product delivered"
+                    }
+                  },
+                  "tracking": true,
+                  "start": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "time": {
+                      "duration": "P0DT0H1M",
+                      "range": {
+                        "start": "2025-04-24T09:00:00.000Z",
+                        "end": "2025-04-24T23:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:01:35.578Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Pickup",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "28.4554726,77.0219019",
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      }
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "time": {
+                      "range": {
+                        "start": "2025-04-25T09:30:00.000Z",
+                        "end": "2025-04-25T19:00:00.000Z"
+                      },
+                      "timestamp": "2025-04-24T18:02:23.474Z"
+                    },
+                    "instructions": {
+                      "name": "Proof Of Delivery",
+                      "images": [
+                        "http://sequelstring-lsp-ondc.com/proof"
+                      ]
+                    }
+                  },
+                  "tags": null,
+                  "agent": {
+                    "name": "Tom Hagen",
+                    "phone": "9876543210"
+                  },
+                  "vehicle": {
+                    "registration": "3LVJ945"
+                  }
+                },
+                {
+                  "id": "ce69a8d9-e7b9-4f64-8879-8dffe2783019",
+                  "type": "Return",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "state": {
+                    "descriptor": {
+                      "code": "Return_Delivered",
+                      "name": "Return is delivered to the merchant location"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": ""
+                    },
+                    "time": {
+                      "timestamp": "2025-04-24T18:05:08.511Z"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code"
+                    },
+                    "time": {
+                      "timestamp": "2025-04-24T18:05:24.958Z"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "return_request",
+                      "list": [
+                        {
+                          "code": "id",
+                          "value": "ce69a8d9-e7b9-4f64-8879-8dffe2783019"
+                        },
+                        {
+                          "code": "item_id",
+                          "value": "676a6179cac4860876a8e30b"
+                        },
+                        {
+                          "code": "item_quantity",
+                          "value": "2"
+                        },
+                        {
+                          "code": "reason_id",
+                          "value": "003"
+                        },
+                        {
+                          "code": "reason_desc",
+                          "value": "some detailed reason for return"
+                        },
+                        {
+                          "code": "images",
+                          "value": "https://some-images-for-item.com"
+                        },
+                        {
+                          "code": "ttl_approval",
+                          "value": "PT24H"
+                        },
+                        {
+                          "code": "ttl_reverseqc",
+                          "value": "P3D"
+                        },
+                        {
+                          "code": "initiated_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "quote_trail",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "item"
+                        },
+                        {
+                          "code": "id",
+                          "value": "676a6179cac4860876a8e30b"
+                        },
+                        {
+                          "code": "currency",
+                          "value": "INR"
+                        },
+                        {
+                          "code": "value",
+                          "value": "-800.00"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "quote_trail",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "discount"
+                        },
+                        {
+                          "code": "id",
+                          "value": "676a6179cac4860876a8e30b"
+                        },
+                        {
+                          "code": "currency",
+                          "value": "INR"
+                        },
+                        {
+                          "code": "value",
+                          "value": "40.00"
+                        }
+                      ]
+                    }
+                  ],
+                  "category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D"
+                },
+                {
+                  "id": "9f4b8ecb-8389-4034-98f1-f371436e1e4e",
+                  "type": "Return",
+                  "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                  "state": {
+                    "descriptor": {
+                      "code": "Return_Delivered",
+                      "name": "Return is delivered to the merchant location"
+                    }
+                  },
+                  "start": {
+                    "location": {
+                      "address": {
+                        "name": "Nirdosh Chauhan",
+                        "building": "221 B",
+                        "locality": "Baker Steeet",
+                        "city": "Gurgaon",
+                        "state": "Haryana",
+                        "country": "India",
+                        "area_code": "122007"
+                      },
+                      "gps": "28.4554726,77.0219019"
+                    },
+                    "contact": {
+                      "phone": "9876543210",
+                      "email": "nirdosh.chauhan@sequelstring.com"
+                    },
+                    "instructions": {
+                      "name": "Proof of pickup",
+                      "code": "3",
+                      "short_desc": ""
+                    },
+                    "time": {
+                      "timestamp": "2025-04-24T18:05:08.531Z"
+                    }
+                  },
+                  "end": {
+                    "location": {
+                      "gps": "12.9263841,77.6654374",
+                      "address": {
+                        "name": "Lekhha_Seller_1",
+                        "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                        "locality": "Bengaluru",
+                        "city": "Bengaluru",
+                        "state": "KA",
+                        "country": "IND",
+                        "area_code": "560103"
+                      }
+                    },
+                    "contact": {
+                      "email": "Lekhha_Seller_1@email1.com",
+                      "phone": "9900025784"
+                    },
+                    "instructions": {
+                      "name": "Proof of delivery",
+                      "code": "3",
+                      "short_desc": "no delivery code"
+                    },
+                    "time": {
+                      "timestamp": "2025-04-24T18:05:24.976Z"
+                    }
+                  },
+                  "tags": [
+                    {
+                      "code": "return_request",
+                      "list": [
+                        {
+                          "code": "id",
+                          "value": "9f4b8ecb-8389-4034-98f1-f371436e1e4e"
+                        },
+                        {
+                          "code": "item_id",
+                          "value": "676a6126cac4860876a8e309"
+                        },
+                        {
+                          "code": "item_quantity",
+                          "value": "3"
+                        },
+                        {
+                          "code": "reason_id",
+                          "value": "003"
+                        },
+                        {
+                          "code": "reason_desc",
+                          "value": "some detailed reason for return"
+                        },
+                        {
+                          "code": "images",
+                          "value": "https://some-images-for-item.com"
+                        },
+                        {
+                          "code": "ttl_approval",
+                          "value": "PT24H"
+                        },
+                        {
+                          "code": "ttl_reverseqc",
+                          "value": "P3D"
+                        },
+                        {
+                          "code": "initiated_by",
+                          "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "quote_trail",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "item"
+                        },
+                        {
+                          "code": "id",
+                          "value": "676a6126cac4860876a8e309"
+                        },
+                        {
+                          "code": "currency",
+                          "value": "INR"
+                        },
+                        {
+                          "code": "value",
+                          "value": "-120.00"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "quote_trail",
+                      "list": [
+                        {
+                          "code": "type",
+                          "value": "discount"
+                        },
+                        {
+                          "code": "id",
+                          "value": "676a6126cac4860876a8e309"
+                        },
+                        {
+                          "code": "currency",
+                          "value": "INR"
+                        },
+                        {
+                          "code": "value",
+                          "value": "0.00"
+                        }
+                      ]
+                    }
+                  ],
+                  "category": "Standard Delivery",
+                  "@ondc/org/TAT": "P1D"
+                }
+              ],
+              "quote": {
+                "price": {
+                  "currency": "INR",
+                  "value": "5311.70"
+                },
+                "ttl": "P1D",
+                "breakup": [
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "@ondc/org/item_quantity": {
+                      "count": 0
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "400.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "@ondc/org/item_quantity": {
+                      "count": 0
+                    },
+                    "title": "Milk blue",
+                    "@ondc/org/title_type": "item",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0.00"
+                    },
+                    "item": {
+                      "price": {
+                        "currency": "INR",
+                        "value": "40.00"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                    "title": "Discount",
+                    "@ondc/org/title_type": "discount",
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Delivery charges",
+                    "@ondc/org/title_type": "delivery",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                    "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "lsp_item_details": {
+                      "id": "std_del",
+                      "parent_item_id": "",
+                      "descriptor": {
+                        "code": "P2P",
+                        "name": "Standard Delivery",
+                        "long_desc": "Upto 1 day for Delivery",
+                        "short_desc": "Upto 1 day for Delivery"
+                      },
+                      "category_id": "Standard Delivery",
+                      "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                      "price": {
+                        "currency": "INR",
+                        "value": "5204.12"
+                      },
+                      "time": {
+                        "label": "TAT",
+                        "duration": "P1D",
+                        "timestamp": "2025-04-25"
+                      }
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Packing charges",
+                    "@ondc/org/title_type": "packing",
+                    "price": {
+                      "currency": "INR",
+                      "value": "33"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Convenience Fee",
+                    "@ondc/org/title_type": "misc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "66.44"
+                    }
+                  },
+                  {
+                    "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "title": "Tax",
+                    "@ondc/org/title_type": "tax",
+                    "price": {
+                      "currency": "INR",
+                      "value": "8.14"
+                    },
+                    "item": {
+                      "tags": [
+                        {
+                          "code": "quote",
+                          "list": [
+                            {
+                              "code": "type",
+                              "value": "fulfillment"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "payment": {
+                "type": "ON-ORDER",
+                "params": {
+                  "amount": "6191.70",
+                  "currency": "INR",
+                  "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+                },
+                "status": "PAID",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_basis": "delivery",
+                "@ondc/org/settlement_window": "P1D",
+                "@ondc/org/withholding_amount": "10.00",
+                "@ondc/org/collected_by_status": "Agree",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                  {
+                    "settlement_counterparty": "seller-app",
+                    "settlement_phase": "sale-amount",
+                    "settlement_type": "upi",
+                    "beneficiary_name": "Lekhha NP",
+                    "upi_address": "testLekhhaup.com",
+                    "settlement_bank_account_no": "testLekhhaBankAcc",
+                    "settlement_ifsc_code": "testLekhhaIfsc",
+                    "bank_name": "testLekhhaBank",
+                    "branch_name": "testLekhhaBranch"
+                  }
+                ]
+              },
+              "created_at": "2025-04-24T18:00:38.223Z",
+              "updated_at": "2025-04-24T18:05:24.980Z",
+              "documents": [
+                {
+                  "url": "https://stageapi.lekhha.com/Misc/Invoice/productImages/680a7c3948665475e6bf8d27.pdf",
+                  "label": "Invoice"
+                }
+              ]
+            }
+          }
+        },
+        "response": {
+          "context": {
+            "domain": "ONDC:RET10",
+            "country": "IND",
+            "city": "std:080",
+            "core_version": "1.2.0",
+            "action": "on_update",
+            "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+            "message_id": "f7374856-d520-4258-9429-487b11f5ec5c",
+            "timestamp": "2025-04-24T18:05:24.980Z",
+            "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+            "bpp_id": "stageapi.lekhha.com",
+            "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+          },
+          "message": {
+            "ack": {
+              "status": "ACK"
+            }
+          }
+        }
+      }
+    }
+  }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_confirm.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_confirm.json
@@ -1,0 +1,140 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "confirm",
+          "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+          "message_id": "f393797d-2d82-45ef-88ec-f419cb73f4ad",
+          "timestamp": "2025-04-24T18:02:50.655Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT30S",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                "category_id": "Standard Delivery",
+                "descriptor": {
+                  "code": "P2P"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                }
+              }
+            ],
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "state": "Created",
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "tags": [
+              {
+                "code": "bap_terms",
+                "list": [
+                  {
+                    "code": "accept_bpp_terms",
+                    "value": "Y"
+                  }
+                ]
+              }
+            ],
+            "updated_at": "2025-04-24T18:02:50.646Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_init.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_init.json
@@ -1,0 +1,97 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "init",
+          "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+          "message_id": "70890cdf-8ec0-408c-be98-9d62008f8673",
+          "timestamp": "2025-04-24T18:02:48.607Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT30S",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                "category_id": "Standard Delivery",
+                "descriptor": {
+                  "code": "P2P"
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_on_confirm.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_on_confirm.json
@@ -1,0 +1,144 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_confirm",
+          "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+          "message_id": "f393797d-2d82-45ef-88ec-f419cb73f4ad",
+          "timestamp": "2025-04-24T18:02:50.694Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT10M",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+        },
+        "message": {
+          "order": {
+            "state": "Accepted",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Pending"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "updated_at": "2025-04-24T18:02:50.694Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_on_init.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_on_init.json
@@ -1,0 +1,102 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_init",
+          "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+          "message_id": "70890cdf-8ec0-408c-be98-9d62008f8673",
+          "timestamp": "2025-04-24T18:02:48.640Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT10M",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434"
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                }
+              }
+            ],
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ],
+              "ttl": "P7D"
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_on_search.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_on_search.json
@@ -1,0 +1,414 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_search",
+          "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+          "message_id": "42f5db26-b841-4113-8173-3281489aeb2f",
+          "timestamp": "2025-04-24T18:02:41.118Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT30S",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+        },
+        "message": {
+          "catalog": {
+            "bpp/descriptor": {
+              "name": "ONDC Pramaaan Logistics"
+            },
+            "bpp/providers": [
+              {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                "descriptor": {
+                  "name": "ONDC Pramaaan Logistics",
+                  "short_desc": "Swiftly Yours, Delivered with Care",
+                  "long_desc": "We deliver everywhere—yes, even Mars (just give us a little more rocket fuel)."
+                },
+                "categories": [
+                  {
+                    "id": "Standard Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "Immediate Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2025-04-24"
+                    }
+                  },
+                  {
+                    "id": "Express Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "Next Day Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "Same Day Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT4H",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                ],
+                "fulfillments": [
+                  {
+                    "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT15M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "135cc127-eef0-4f38-99de-71174bbcb5fb",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT20M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "201555bf-b31a-40f8-ac78-467088f92835",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT30M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "16c5b709-65fc-454c-ba9c-d6d9b5af3fe7",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT30M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "c27685b7-275b-4520-93ec-c5f84ba04c75",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT15M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "64cfd1e4-8c1e-4465-b132-d1b820e79a8c",
+                    "type": "RTO"
+                  }
+                ],
+                "items": [
+                  {
+                    "id": "rto_std",
+                    "parent_item_id": "std_del",
+                    "category_id": "Standard Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "fulfillment_id": "64cfd1e4-8c1e-4465-b132-d1b820e79a8c",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "rto_imd",
+                    "parent_item_id": "imd_del",
+                    "category_id": "Immediate Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Immediate Delivery",
+                      "long_desc": "Upto 60 mins for Delivery",
+                      "short_desc": "Upto 60 mins for Delivery"
+                    },
+                    "fulfillment_id": "64cfd1e4-8c1e-4465-b132-d1b820e79a8c",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2025-04-24"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "imd_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Immediate Delivery",
+                      "long_desc": "Upto 60 mins for Delivery",
+                      "short_desc": "Upto 60 mins for Delivery"
+                    },
+                    "category_id": "Immediate Delivery",
+                    "fulfillment_id": "135cc127-eef0-4f38-99de-71174bbcb5fb",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2025-04-24"
+                    }
+                  },
+                  {
+                    "id": "rto_exp",
+                    "parent_item_id": "exp_del",
+                    "category_id": "Express Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Express Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "fulfillment_id": "64cfd1e4-8c1e-4465-b132-d1b820e79a8c",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "exp_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Express Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Express Delivery",
+                    "fulfillment_id": "201555bf-b31a-40f8-ac78-467088f92835",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "rto_nex",
+                    "parent_item_id": "nex_del",
+                    "category_id": "Next Day Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Next Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "fulfillment_id": "64cfd1e4-8c1e-4465-b132-d1b820e79a8c",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "nex_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Next Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Next Day Delivery",
+                    "fulfillment_id": "16c5b709-65fc-454c-ba9c-d6d9b5af3fe7",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "rto_same",
+                    "parent_item_id": "same_del",
+                    "category_id": "Same Day Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Same Day Delivery",
+                      "long_desc": "Same Delivery",
+                      "short_desc": "Same for Delivery"
+                    },
+                    "fulfillment_id": "64cfd1e4-8c1e-4465-b132-d1b820e79a8c",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT4H",
+                      "timestamp": "2025-04-24"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "same_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Same Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Same Day Delivery",
+                    "fulfillment_id": "c27685b7-275b-4520-93ec-c5f84ba04c75",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT4H",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_on_status_1_agent_assigned.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_on_status_1_agent_assigned.json
@@ -1,0 +1,151 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+          "message_id": "c2c3e12c-16dd-4978-9007-a6a90feb6c02",
+          "timestamp": "2025-04-24T18:03:41.209Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT50S",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+        },
+        "message": {
+          "order": {
+            "state": "In-progress",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Agent-assigned"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "updated_at": "2025-04-24T18:03:41.209Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_on_status_2_response.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_on_status_2_response.json
@@ -1,0 +1,151 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+          "message_id": "a3df04d2-ac4a-4148-a947-b993e7eeb8f9",
+          "timestamp": "2025-04-24T18:04:28.346Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT10M",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+        },
+        "message": {
+          "order": {
+            "state": "In-progress",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Agent-assigned"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "updated_at": "2025-04-24T18:03:41.209Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_on_status_3_out_for_delivery.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_on_status_3_out_for_delivery.json
@@ -1,0 +1,151 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+          "message_id": "7998a4ec-cfa8-4fb7-8319-3823bddbe8af",
+          "timestamp": "2025-04-24T18:05:08.320Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT50S",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+        },
+        "message": {
+          "order": {
+            "state": "In-progress",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Out-for-delivery"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "updated_at": "2025-04-24T18:05:08.320Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_on_status_4_delivered.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_on_status_4_delivered.json
@@ -1,0 +1,163 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+          "message_id": "9ed254a1-7528-4c75-93dc-ef20ab9e9fb8",
+          "timestamp": "2025-04-24T18:05:24.755Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT50S",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+        },
+        "message": {
+          "order": {
+            "state": "Completed",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "83d3d0fd-24cc-48a5-9476-f765672eb434",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-delivered"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "timestamp": "2025-04-24T18:05:24.755Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Delivery",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "time": {
+                "timestamp": "2025-04-24T18:05:24.755Z"
+              }
+            },
+            "updated_at": "2025-04-24T18:05:24.755Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_search.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_search.json
@@ -1,0 +1,82 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "search",
+          "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+          "message_id": "42f5db26-b841-4113-8173-3281489aeb2f",
+          "timestamp": "2025-04-24T18:02:40.995Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "intent": {
+            "category": {
+              "id": "Standard Delivery"
+            },
+            "provider": {
+              "time": {
+                "days": "1,2,3,4,5,6,7",
+                "schedule": {
+                  "holidays": []
+                },
+                "range": {
+                  "start": "0001",
+                  "end": "2359"
+                }
+              }
+            },
+            "fulfillment": {
+              "type": "Delivery",
+              "start": {
+                "location": {
+                  "gps": "28.4554726,77.0219019",
+                  "address": {
+                    "area_code": "560103"
+                  }
+                }
+              },
+              "end": {
+                "location": {
+                  "gps": "12.9263841,77.6654374",
+                  "address": {
+                    "area_code": "560103"
+                  }
+                }
+              }
+            },
+            "payment": {
+              "type": "ON-ORDER"
+            },
+            "@ondc/org/payload_details": {
+              "weight": {
+                "unit": "gram",
+                "value": 1720
+              },
+              "dimensions": {
+                "length": {
+                  "unit": "centimeter",
+                  "value": 119
+                },
+                "breadth": {
+                  "unit": "centimeter",
+                  "value": 35
+                },
+                "height": {
+                  "unit": "centimeter",
+                  "value": 25
+                }
+              },
+              "category": "Grocery",
+              "value": {
+                "currency": "INR",
+                "value": "880"
+              },
+              "dangerous_goods": false
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_status_request.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_Buyer_Return_status_request.json
@@ -1,0 +1,20 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "status",
+          "transaction_id": "8181d321-8206-4aa6-8931-643428e45814",
+          "message_id": "a3df04d2-ac4a-4148-a947-b993e7eeb8f9",
+          "timestamp": "2025-04-24T18:04:26.769Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT30S",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+        },
+        "message": {
+          "order_id": "SS1745517638223"
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_confirm.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_confirm.json
@@ -1,0 +1,238 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "confirm",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "5dcd7590-fd8b-41da-9d16-5b2698b51069",
+          "timestamp": "2025-04-24T18:00:38.517Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "category_id": "Standard Delivery",
+                "descriptor": {
+                  "code": "P2P"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "id": "SS1745517638223",
+            "state": "Created",
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517638223",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "tags": [
+              {
+                "code": "bap_terms",
+                "list": [
+                  {
+                    "code": "accept_bpp_terms",
+                    "value": "Y"
+                  }
+                ]
+              }
+            ],
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:00:38.476Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_init.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_init.json
@@ -1,0 +1,97 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "init",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "d33c7a24-7cbc-4b85-8f6d-6807019414ae",
+          "timestamp": "2025-04-24T18:00:22.865Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "category_id": "Standard Delivery",
+                "descriptor": {
+                  "code": "P2P"
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_confirm.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_confirm.json
@@ -1,0 +1,240 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_confirm",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "5dcd7590-fd8b-41da-9d16-5b2698b51069",
+          "timestamp": "2025-04-24T18:00:38.562Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT10M"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "Accepted",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Pending"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517638223",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:00:38.562Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_init.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_init.json
@@ -1,0 +1,102 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_init",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "d33c7a24-7cbc-4b85-8f6d-6807019414ae",
+          "timestamp": "2025-04-24T18:00:22.909Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT10M"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                }
+              }
+            ],
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ],
+              "ttl": "P7D"
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_search.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_search.json
@@ -1,0 +1,414 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_search",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "162777d5-ee92-43a0-ac39-cbc83e272f82",
+          "timestamp": "2025-04-24T17:59:51.932Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT30S",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller"
+        },
+        "message": {
+          "catalog": {
+            "bpp/descriptor": {
+              "name": "ONDC Pramaaan Logistics"
+            },
+            "bpp/providers": [
+              {
+                "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                "descriptor": {
+                  "name": "ONDC Pramaaan Logistics",
+                  "short_desc": "Swiftly Yours, Delivered with Care",
+                  "long_desc": "We deliver everywhere—yes, even Mars (just give us a little more rocket fuel)."
+                },
+                "categories": [
+                  {
+                    "id": "Standard Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "Immediate Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2025-04-24"
+                    }
+                  },
+                  {
+                    "id": "Express Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "Next Day Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "Same Day Delivery",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT4H",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                ],
+                "fulfillments": [
+                  {
+                    "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT15M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT20M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "37260627-31f5-461f-b01c-67c16a6b69b3",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT30M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "5476be14-c110-4772-a03b-8d28924827bc",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT30M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ed4b869a-0023-4bcf-a533-a0536667b63f",
+                    "type": "Delivery",
+                    "start": {
+                      "time": {
+                        "duration": "PT15M"
+                      }
+                    },
+                    "tags": [
+                      {
+                        "code": "distance",
+                        "list": [
+                          {
+                            "code": "motorable_distance_type",
+                            "value": "kilometer"
+                          },
+                          {
+                            "code": "motorable_distance",
+                            "value": "1728.04"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "80262053-367c-4eb0-a081-57549dfdf841",
+                    "type": "RTO"
+                  }
+                ],
+                "items": [
+                  {
+                    "id": "rto_std",
+                    "parent_item_id": "std_del",
+                    "category_id": "Standard Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "fulfillment_id": "80262053-367c-4eb0-a081-57549dfdf841",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "rto_imd",
+                    "parent_item_id": "imd_del",
+                    "category_id": "Immediate Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Immediate Delivery",
+                      "long_desc": "Upto 60 mins for Delivery",
+                      "short_desc": "Upto 60 mins for Delivery"
+                    },
+                    "fulfillment_id": "80262053-367c-4eb0-a081-57549dfdf841",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2025-04-24"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "imd_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Immediate Delivery",
+                      "long_desc": "Upto 60 mins for Delivery",
+                      "short_desc": "Upto 60 mins for Delivery"
+                    },
+                    "category_id": "Immediate Delivery",
+                    "fulfillment_id": "8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2025-04-24"
+                    }
+                  },
+                  {
+                    "id": "rto_exp",
+                    "parent_item_id": "exp_del",
+                    "category_id": "Express Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Express Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "fulfillment_id": "80262053-367c-4eb0-a081-57549dfdf841",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "exp_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Express Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Express Delivery",
+                    "fulfillment_id": "37260627-31f5-461f-b01c-67c16a6b69b3",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "rto_nex",
+                    "parent_item_id": "nex_del",
+                    "category_id": "Next Day Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Next Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "fulfillment_id": "80262053-367c-4eb0-a081-57549dfdf841",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "nex_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Next Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Next Day Delivery",
+                    "fulfillment_id": "5476be14-c110-4772-a03b-8d28924827bc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  },
+                  {
+                    "id": "rto_same",
+                    "parent_item_id": "same_del",
+                    "category_id": "Same Day Delivery",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Same Day Delivery",
+                      "long_desc": "Same Delivery",
+                      "short_desc": "Same for Delivery"
+                    },
+                    "fulfillment_id": "80262053-367c-4eb0-a081-57549dfdf841",
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT4H",
+                      "timestamp": "2025-04-24"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2612.06"
+                    }
+                  },
+                  {
+                    "id": "same_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Same Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Same Day Delivery",
+                    "fulfillment_id": "ed4b869a-0023-4bcf-a533-a0536667b63f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT4H",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_status_1_agent_assigned.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_status_1_agent_assigned.json
@@ -1,0 +1,253 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "6ceed9b2-dc07-4084-970b-7f502bda4dd3",
+          "timestamp": "2025-04-24T18:01:29.464Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT50S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "In-progress",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Agent-assigned"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517638223",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:01:29.464Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_status_2_picked_up.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_status_2_picked_up.json
@@ -1,0 +1,278 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "ef2ce20b-0b88-4b6b-a253-774749b55bf8",
+          "timestamp": "2025-04-24T18:01:35.578Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT50S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "In-progress",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-picked-up"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:01:35.578Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "status": "NOT-PAID"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517638223",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:01:35.578Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_status_3_out_for_delivery.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_status_3_out_for_delivery.json
@@ -1,0 +1,278 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "799d6106-8ce9-413d-9f53-a4ec1f817330",
+          "timestamp": "2025-04-24T18:01:41.598Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT50S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "In-progress",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Out-for-delivery"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:01:35.578Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "status": "NOT-PAID"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517638223",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:01:41.598Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_status_4_response.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_status_4_response.json
@@ -1,0 +1,278 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "6e45ee7e-4951-4754-bafd-5dbde78d723e",
+          "timestamp": "2025-04-24T18:02:09.065Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT10M"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "In-progress",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Out-for-delivery"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:01:35.578Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "status": "NOT-PAID"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517638223",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:01:41.598Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_status_5_delivered.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_status_5_delivered.json
@@ -1,0 +1,288 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "e8b8b775-a129-4890-afcd-165c74c8f9d1",
+          "timestamp": "2025-04-24T18:02:23.474Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT50S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "Completed",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-delivered"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:01:35.578Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:02:23.474Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Delivery",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "tracking",
+                    "list": [
+                      {
+                        "code": "gps_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url_enabled",
+                        "value": "yes"
+                      },
+                      {
+                        "code": "url",
+                        "value": "http://sequelstring-lsp-ondc.com/track"
+                      }
+                    ]
+                  }
+                ],
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER",
+              "status": "NOT-PAID",
+              "time": {
+                "timestamp": "2025-04-24T18:02:23.474Z"
+              }
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517638223",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:02:23.474Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_update_RTS_response.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_on_update_RTS_response.json
@@ -1,0 +1,246 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_update",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "fe2f028b-cb77-4be1-aec0-3eb3d4c9b7cc",
+          "timestamp": "2025-04-24T18:01:20.293Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT10M"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "Accepted",
+            "provider": {
+              "id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c"
+            },
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "descriptor": {
+                  "code": "P2P",
+                  "name": "Standard Delivery",
+                  "long_desc": "Upto 1 day for Delivery",
+                  "short_desc": "Upto 1 day for Delivery"
+                },
+                "time": {
+                  "label": "TAT",
+                  "duration": "P1D",
+                  "timestamp": "2025-04-25"
+                }
+              }
+            ],
+            "billing": {
+              "name": "Lekhha_Seller_1",
+              "address": {
+                "name": "Lekhha_Seller_1",
+                "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                "locality": "Bengaluru",
+                "city": "Bengaluru",
+                "state": "KA",
+                "country": "IND",
+                "area_code": "560103"
+              },
+              "tax_number": "gstin1",
+              "phone": "9900025784",
+              "email": "Lekhha_Seller_1@email1.com",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Searching-for-Agent"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship ",
+                        "value": "no"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "rto_action",
+                    "list": [
+                      {
+                        "code": "return_to_origin ",
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5204.12"
+              },
+              "breakup": [
+                {
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "delivery"
+                },
+                {
+                  "title": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "@ondc/org/item_id": "std_del",
+                  "@ondc/org/title_type": "tax"
+                }
+              ]
+            },
+            "payment": {
+              "collected_by": "BPP",
+              "type": "ON-ORDER"
+            },
+            "@ondc/org/linked_order": {
+              "items": [
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 2,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 10
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "380.000"
+                  }
+                },
+                {
+                  "category_id": "Grocery",
+                  "descriptor": {
+                    "name": "Milk blue"
+                  },
+                  "quantity": {
+                    "count": 3,
+                    "measure": {
+                      "unit": "unit",
+                      "value": 1
+                    }
+                  },
+                  "price": {
+                    "currency": "INR",
+                    "value": "40.000"
+                  }
+                }
+              ],
+              "provider": {
+                "descriptor": {
+                  "name": "Lekhha Provider A"
+                },
+                "address": {
+                  "name": "Lekhha_Seller_1",
+                  "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                  "locality": "Bengaluru",
+                  "city": "Bengaluru",
+                  "state": "KA",
+                  "country": "IND",
+                  "area_code": "560103"
+                }
+              },
+              "order": {
+                "id": "SS1745517638223",
+                "weight": {
+                  "unit": "gram",
+                  "value": 1720
+                },
+                "dimensions": {
+                  "length": {
+                    "unit": "centimeter",
+                    "value": 119
+                  },
+                  "breadth": {
+                    "unit": "centimeter",
+                    "value": 35
+                  },
+                  "height": {
+                    "unit": "centimeter",
+                    "value": 25
+                  }
+                }
+              }
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:00:38.562Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_search.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_search.json
@@ -1,0 +1,83 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "search",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "162777d5-ee92-43a0-ac39-cbc83e272f82",
+          "timestamp": "2025-04-24T17:59:50.882Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "intent": {
+            "category": {
+              "id": "Standard Delivery"
+            },
+            "provider": {
+              "time": {
+                "days": "1,2,3,4,5,6,7",
+                "schedule": {
+                  "holidays": []
+                },
+                "duration": "P0DT0H1M",
+                "range": {
+                  "start": "0001",
+                  "end": "2359"
+                }
+              }
+            },
+            "fulfillment": {
+              "type": "Delivery",
+              "start": {
+                "location": {
+                  "gps": "12.9263841,77.6654374",
+                  "address": {
+                    "area_code": "560103"
+                  }
+                }
+              },
+              "end": {
+                "location": {
+                  "gps": "28.4554726,77.0219019",
+                  "address": {
+                    "area_code": "122007"
+                  }
+                }
+              }
+            },
+            "payment": {
+              "type": "ON-ORDER"
+            },
+            "@ondc/org/payload_details": {
+              "weight": {
+                "unit": "gram",
+                "value": 1720
+              },
+              "dimensions": {
+                "length": {
+                  "unit": "centimeter",
+                  "value": 119
+                },
+                "breadth": {
+                  "unit": "centimeter",
+                  "value": 35
+                },
+                "height": {
+                  "unit": "centimeter",
+                  "value": 25
+                }
+              },
+              "category": "Grocery",
+              "value": {
+                "currency": "INR",
+                "value": "880"
+              },
+              "dangerous_goods": false
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_status_request.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_status_request.json
@@ -1,0 +1,20 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "status",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "6e45ee7e-4951-4754-bafd-5dbde78d723e",
+          "timestamp": "2025-04-24T18:02:07.580Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order_id": "SS1745517638223"
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_update_RTS_request.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/LBNP_update_RTS_request.json
@@ -1,0 +1,90 @@
+{
+        "context": {
+          "domain": "nic2004:60232",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "update",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "fe2f028b-cb77-4be1-aec0-3eb3d4c9b7cc",
+          "timestamp": "2025-04-24T18:01:14.451Z",
+          "bap_uri": "https://stageapi.lekhha.com/buyerLogistics",
+          "bap_id": "stageapi.lekhha.com",
+          "bpp_id": "pramaan.ondc.org/beta/preprod/mock/seller",
+          "bpp_uri": "https://pramaan.ondc.org/beta/preprod/mock/seller",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "update_target": "fulfillment",
+          "order": {
+            "id": "SS1745517638223",
+            "state": "Created",
+            "items": [
+              {
+                "id": "std_del",
+                "category_id": "Standard Delivery",
+                "descriptor": {
+                  "code": "P2P"
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "state",
+                    "list": [
+                      {
+                        "code": "ready_to_ship",
+                        "value": "yes"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "updated_at": "2025-04-24T23:31:14.439Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_confirm.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_confirm.json
@@ -1,0 +1,335 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "confirm",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "b7d08080-fa7e-4479-a5a3-6e12e19b7820",
+          "timestamp": "2025-04-24T18:00:38.223Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "Created",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D",
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": "other pickup confirmation code",
+                    "long_desc": "Pls pickup orders from counter number 01."
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "person": {
+                    "name": "Nirdosh Chauhan"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "tags": [
+              {
+                "code": "bpp_terms",
+                "list": [
+                  {
+                    "code": "np_type",
+                    "value": "MSN"
+                  },
+                  {
+                    "code": "collect_payment",
+                    "value": "Y"
+                  },
+                  {
+                    "code": "max_liability",
+                    "value": "2"
+                  },
+                  {
+                    "code": "max_liability_cap",
+                    "value": "10000"
+                  },
+                  {
+                    "code": "mandatory_arbitration",
+                    "value": "false"
+                  },
+                  {
+                    "code": "court_jurisdiction",
+                    "value": "Bengaluru"
+                  },
+                  {
+                    "code": "delay_interest",
+                    "value": "7"
+                  },
+                  {
+                    "code": "tax_number",
+                    "value": "29ABGCS7802J1ZX"
+                  },
+                  {
+                    "code": "provider_tax_number",
+                    "value": "ABGCS7802J"
+                  }
+                ]
+              },
+              {
+                "code": "bap_terms",
+                "list": [
+                  {
+                    "code": "tax_number",
+                    "value": "00XYZAB1234C1Z8"
+                  },
+                  {
+                    "code": "accept_bpp_terms",
+                    "value": "Y"
+                  }
+                ]
+              }
+            ],
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Assert",
+              "collected_by": "BAP"
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:00:38.223Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_init.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_init.json
@@ -1,0 +1,88 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "init",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "1d449241-9b55-4783-a015-d5d16ae1cf8a",
+          "timestamp": "2025-04-24T18:00:22.623Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "ttl": "PT30S",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_confirm.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_confirm.json
@@ -1,0 +1,354 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_confirm",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "b7d08080-fa7e-4479-a5a3-6e12e19b7820",
+          "timestamp": "2025-04-24T18:00:43.697Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "Created",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D",
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": "other pickup confirmation code",
+                    "long_desc": "Pls pickup orders from counter number 01."
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T17:30:00.000Z",
+                      "end": "2025-04-24T19:30:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "instructions": {
+                    "name": "Proof of delivery",
+                    "code": "3",
+                    "short_desc": "no delivery code",
+                    "long_desc": ""
+                  },
+                  "time": {
+                    "range": {
+                      "end": "2025-04-24T18:03:43.679Z"
+                    }
+                  }
+                },
+                "state": {
+                  "descriptor": {
+                    "code": "Pending",
+                    "name": "Getting ready for shipment (packaging)"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "tags": [
+              {
+                "code": "bpp_terms",
+                "list": [
+                  {
+                    "code": "np_type",
+                    "value": "MSN"
+                  },
+                  {
+                    "code": "collect_payment",
+                    "value": "Y"
+                  },
+                  {
+                    "code": "max_liability",
+                    "value": "2"
+                  },
+                  {
+                    "code": "max_liability_cap",
+                    "value": "10000"
+                  },
+                  {
+                    "code": "mandatory_arbitration",
+                    "value": "false"
+                  },
+                  {
+                    "code": "court_jurisdiction",
+                    "value": "Bengaluru"
+                  },
+                  {
+                    "code": "delay_interest",
+                    "value": "7"
+                  },
+                  {
+                    "code": "tax_number",
+                    "value": "29ABGCS7802J1ZX"
+                  },
+                  {
+                    "code": "provider_tax_number",
+                    "value": "ABGCS7802J"
+                  }
+                ]
+              },
+              {
+                "code": "bap_terms",
+                "list": [
+                  {
+                    "code": "tax_number",
+                    "value": "00XYZAB1234C1Z8"
+                  },
+                  {
+                    "code": "accept_bpp_terms",
+                    "value": "Y"
+                  }
+                ]
+              }
+            ],
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Assert",
+              "collected_by": "BAP"
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:00:43.697Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_init.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_init.json
@@ -1,0 +1,313 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_init",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "1d449241-9b55-4783-a015-d5d16ae1cf8a",
+          "timestamp": "2025-04-24T18:00:25.856Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D",
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": "other pickup confirmation code",
+                    "long_desc": "Pls pickup orders from counter number 01."
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "currency": "INR",
+                "amount": "0"
+              },
+              "status": "NOT-PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "return_window_expiry",
+              "@ondc/org/settlement_window": "P2D",
+              "@ondc/org/withholding_amount": "0",
+              "@ondc/org/collected_by_status": "Assert",
+              "collected_by": "BPP"
+            },
+            "tags": [
+              {
+                "code": "bpp_terms",
+                "list": [
+                  {
+                    "code": "np_type",
+                    "value": "MSN"
+                  },
+                  {
+                    "code": "collect_payment",
+                    "value": "Y"
+                  },
+                  {
+                    "code": "max_liability",
+                    "value": "2"
+                  },
+                  {
+                    "code": "max_liability_cap",
+                    "value": "10000"
+                  },
+                  {
+                    "code": "mandatory_arbitration",
+                    "value": "false"
+                  },
+                  {
+                    "code": "court_jurisdiction",
+                    "value": "Bengaluru"
+                  },
+                  {
+                    "code": "delay_interest",
+                    "value": "7"
+                  },
+                  {
+                    "code": "tax_number",
+                    "value": "29ABGCS7802J1ZX"
+                  },
+                  {
+                    "code": "provider_tax_number",
+                    "value": "ABGCS7802J"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_search.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_search.json
@@ -1,0 +1,1396 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_search",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "2b720846-83aa-4fbd-af77-a819833111c8",
+          "timestamp": "2025-04-24T17:59:19.361Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "ttl": "PT30S",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "catalog": {
+            "bpp/fulfillments": [
+              {
+                "id": "1",
+                "type": "Delivery",
+                "contact": {
+                  "phone": "9900025784",
+                  "email": "sgupta.scm@gmail.com"
+                }
+              }
+            ],
+            "bpp/descriptor": {
+              "name": "Lekhha",
+              "symbol": "https://lekhha.com/wp-content/uploads/2023/07/logo-light-1.png",
+              "short_desc": "App-based platform for order and inventory management.",
+              "long_desc": "LEKHHA is a simple solution to help you comprehensively run your business operations. Discover it to also track & manage your personal needs & resources. Reach out to us to serve you as your solution partner.",
+              "images": [
+                "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/logo",
+                "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/vendor",
+                "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/consumer",
+                "https://stageapi.lekhha.com/Misc/Images/lekhhaImages/inventory"
+              ],
+              "tags": [
+                {
+                  "code": "bpp_terms",
+                  "list": [
+                    {
+                      "code": "np_type",
+                      "value": "MSN"
+                    }
+                  ]
+                }
+              ]
+            },
+            "bpp/providers": [
+              {
+                "id": "674ecb33d7b9e10f4210d972",
+                "time": {
+                  "label": "enable",
+                  "timestamp": "2025-04-24T17:59:18.590Z"
+                },
+                "descriptor": {
+                  "name": "Lekhha Provider A",
+                  "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecb33d7b9e10f4210d972_S",
+                  "short_desc": "Lekhha_Seller_1 kyc short",
+                  "long_desc": "Lekhha_Seller_1 kyc long",
+                  "images": [
+                    "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecb33d7b9e10f4210d972"
+                  ]
+                },
+                "ttl": "P1D",
+                "creds": [
+                  {
+                    "descriptor": {
+                      "code": "Lekhha_Seller_1_cred1",
+                      "name": "Lekhha_Seller_1 cred1",
+                      "short_desc": "Lekhha_Seller_1 cred1 short"
+                    },
+                    "id": "674ecbc6d7b9e10f4210d973_1",
+                    "tags": [
+                      {
+                        "code": "verification",
+                        "list": [
+                          {
+                            "code": "verify_url",
+                            "value": "https://url1url.com/verify1"
+                          },
+                          {
+                            "code": "valid_from",
+                            "value": "2024-12-09T00:00:00.000Z"
+                          },
+                          {
+                            "code": "valid_to",
+                            "value": "2027-03-31T00:00:00.000Z"
+                          }
+                        ]
+                      }
+                    ],
+                    "url": "https://url1url.com"
+                  }
+                ],
+                "fulfillments": [
+                  {
+                    "id": "1",
+                    "type": "Delivery",
+                    "contact": {
+                      "phone": "9900025784",
+                      "email": "sgupta.scm@gmail.com"
+                    }
+                  }
+                ],
+                "tags": [
+                  {
+                    "code": "order_value",
+                    "list": [
+                      {
+                        "code": "min_value",
+                        "value": "150.5"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "timing",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "Order"
+                      },
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "day_from",
+                        "value": "1"
+                      },
+                      {
+                        "code": "day_to",
+                        "value": "7"
+                      },
+                      {
+                        "code": "time_from",
+                        "value": "0001"
+                      },
+                      {
+                        "code": "time_to",
+                        "value": "2359"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "timing",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "Delivery"
+                      },
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "day_from",
+                        "value": "1"
+                      },
+                      {
+                        "code": "day_to",
+                        "value": "7"
+                      },
+                      {
+                        "code": "time_from",
+                        "value": "0001"
+                      },
+                      {
+                        "code": "time_to",
+                        "value": "2359"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "timing",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "Self-Pickup"
+                      },
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "day_from",
+                        "value": "1"
+                      },
+                      {
+                        "code": "day_to",
+                        "value": "7"
+                      },
+                      {
+                        "code": "time_from",
+                        "value": "0001"
+                      },
+                      {
+                        "code": "time_to",
+                        "value": "2359"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "serviceability",
+                    "list": [
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "category",
+                        "value": "Bakery, Cakes & Dairy"
+                      },
+                      {
+                        "code": "type",
+                        "value": "11"
+                      },
+                      {
+                        "code": "val",
+                        "value": "100000-999999"
+                      },
+                      {
+                        "code": "unit",
+                        "value": "pincode"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "serviceability",
+                    "list": [
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "category",
+                        "value": "Energy and Soft Drinks"
+                      },
+                      {
+                        "code": "type",
+                        "value": "11"
+                      },
+                      {
+                        "code": "val",
+                        "value": "100000-999999"
+                      },
+                      {
+                        "code": "unit",
+                        "value": "pincode"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "serviceability",
+                    "list": [
+                      {
+                        "code": "location",
+                        "value": "674ecbc6d7b9e10f4210d973"
+                      },
+                      {
+                        "code": "category",
+                        "value": "Fruits and Vegetables"
+                      },
+                      {
+                        "code": "type",
+                        "value": "11"
+                      },
+                      {
+                        "code": "val",
+                        "value": "100000-999999"
+                      },
+                      {
+                        "code": "unit",
+                        "value": "pincode"
+                      }
+                    ]
+                  }
+                ],
+                "items": [
+                  {
+                    "id": "676a61f6cac4860876a8e30f",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:59:18.859Z"
+                    },
+                    "parent_item_id": "V10000000001",
+                    "descriptor": {
+                      "name": "Milk orange",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Milk orange short",
+                      "long_desc": "Milk orange long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e3_0"
+                      ],
+                      "code": "1:1000000000232"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "13"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "49.82",
+                      "maximum_value": "53.00"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 11",
+                      "additives_info": "additives info 11",
+                      "brand_owner_FSSAI_license_no": "fssai license 11",
+                      "other_FSSAI_license_no": "other license 11",
+                      "importer_FSSAI_license_no": "importer license 11"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 11",
+                      "manufacturer_or_packer_address": "address 11",
+                      "common_or_generic_name_of_commodity": "commodity 11",
+                      "month_year_of_manufacture_packing_import": "year 11"
+                    }
+                  },
+                  {
+                    "id": "676a6179cac4860876a8e30b",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:59:18.887Z"
+                    },
+                    "parent_item_id": "V10000000002",
+                    "descriptor": {
+                      "name": "Milk blue",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Milk blue short",
+                      "long_desc": "Milk blue long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e5_0"
+                      ],
+                      "code": "1:1000000000233"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "10"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "12"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "380.00",
+                      "maximum_value": "400.00"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 9",
+                      "additives_info": "additives info 9",
+                      "brand_owner_FSSAI_license_no": "fssai license 9",
+                      "other_FSSAI_license_no": "other license 9",
+                      "importer_FSSAI_license_no": "importer license 9"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 9",
+                      "manufacturer_or_packer_address": "address 9",
+                      "common_or_generic_name_of_commodity": "commodity 9",
+                      "month_year_of_manufacture_packing_import": "year 9"
+                    }
+                  },
+                  {
+                    "id": "676a6260cac4860876a8e311",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:59:18.921Z"
+                    },
+                    "parent_item_id": "V10000000001",
+                    "descriptor": {
+                      "name": "Milk orange",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Milk orange short",
+                      "long_desc": "Milk orange long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e7_0"
+                      ],
+                      "code": "1:1000000000234"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "10"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "14"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "500.00",
+                      "maximum_value": "500.00"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 12",
+                      "additives_info": "additives info 12",
+                      "brand_owner_FSSAI_license_no": "fssai license 12",
+                      "other_FSSAI_license_no": "other license 12",
+                      "importer_FSSAI_license_no": "importer license 12"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 12",
+                      "manufacturer_or_packer_address": "address 12",
+                      "common_or_generic_name_of_commodity": "commodity 12",
+                      "month_year_of_manufacture_packing_import": "year 12"
+                    }
+                  },
+                  {
+                    "id": "676cf465e5eb3c28a8741e99",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:59:19.004Z"
+                    },
+                    "descriptor": {
+                      "name": "Pista milk",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Pista milk short",
+                      "long_desc": "Pista milk long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd72c_0"
+                      ],
+                      "code": "1:1000000000240"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "32"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "18.50",
+                      "maximum_value": "20.00"
+                    },
+                    "category_id": "Energy and Soft Drinks",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 18",
+                      "additives_info": "additives info 18",
+                      "brand_owner_FSSAI_license_no": "fssai license 18",
+                      "other_FSSAI_license_no": "other license 18",
+                      "importer_FSSAI_license_no": "importer license 18"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 18",
+                      "manufacturer_or_packer_address": "address 18",
+                      "common_or_generic_name_of_commodity": "commodity 18",
+                      "month_year_of_manufacture_packing_import": "year 18"
+                    }
+                  },
+                  {
+                    "id": "676cf465e5eb3c28a8741e9a",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:59:19.021Z"
+                    },
+                    "descriptor": {
+                      "name": "Mango milk",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Mango milk short",
+                      "long_desc": "Mango milk long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd72e_0"
+                      ],
+                      "code": "1:1000000000241"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "33"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "20.16",
+                      "maximum_value": "21.80"
+                    },
+                    "category_id": "Energy and Soft Drinks",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 7",
+                      "additives_info": "additives info 7",
+                      "brand_owner_FSSAI_license_no": "fssai license 7",
+                      "other_FSSAI_license_no": "other license 7",
+                      "importer_FSSAI_license_no": "importer license 7"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 7",
+                      "manufacturer_or_packer_address": "address 7",
+                      "common_or_generic_name_of_commodity": "commodity 7",
+                      "month_year_of_manufacture_packing_import": "year 7"
+                    }
+                  },
+                  {
+                    "id": "676cf465e5eb3c28a8741e9b",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:59:19.040Z"
+                    },
+                    "descriptor": {
+                      "name": "Vanilla milk",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Vanilla milk short",
+                      "long_desc": "Vanilla milk long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd730_0"
+                      ],
+                      "code": "1:1000000000242"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "35"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "18.51",
+                      "maximum_value": "20.01"
+                    },
+                    "category_id": "Energy and Soft Drinks",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 19",
+                      "additives_info": "additives info 19",
+                      "brand_owner_FSSAI_license_no": "fssai license 19",
+                      "other_FSSAI_license_no": "other license 19",
+                      "importer_FSSAI_license_no": "importer license 19"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer name 19",
+                      "manufacturer_or_packer_address": "packer address 19",
+                      "common_or_generic_name_of_commodity": "generic name 19",
+                      "month_year_of_manufacture_packing_import": "month year 19"
+                    }
+                  },
+                  {
+                    "id": "676a5f87cac4860876a8e2ff",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:59:19.057Z"
+                    },
+                    "descriptor": {
+                      "name": "Butter",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Butter short",
+                      "long_desc": "Butter long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd736_0"
+                      ],
+                      "code": "1:1000000000245"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "gram",
+                          "value": "200"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "23"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "109.38",
+                      "maximum_value": "124.30"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 3",
+                      "additives_info": "additives info 3",
+                      "brand_owner_FSSAI_license_no": "fssai license 3",
+                      "other_FSSAI_license_no": "other license 3",
+                      "importer_FSSAI_license_no": "importer license 3"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 13",
+                      "manufacturer_or_packer_address": "address 13",
+                      "common_or_generic_name_of_commodity": "commodity 13",
+                      "month_year_of_manufacture_packing_import": "year 13"
+                    }
+                  },
+                  {
+                    "id": "676a5f11cac4860876a8e2fb",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:59:19.073Z"
+                    },
+                    "descriptor": {
+                      "name": "Burfi",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Burfi short",
+                      "long_desc": "Burfi long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd73a_0"
+                      ],
+                      "code": "1:1000000000247"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "gram",
+                          "value": "200"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "22"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "71.20",
+                      "maximum_value": "80.00"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 2",
+                      "additives_info": "additives info 2",
+                      "brand_owner_FSSAI_license_no": "fssai license 2",
+                      "other_FSSAI_license_no": "other license 2",
+                      "importer_FSSAI_license_no": "importer license 2"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer name 2",
+                      "manufacturer_or_packer_address": "packer address 2",
+                      "common_or_generic_name_of_commodity": "commodity 2",
+                      "month_year_of_manufacture_packing_import": "packing import 2"
+                    }
+                  },
+                  {
+                    "id": "676aab3800d7d9212e3ba074",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:59:19.091Z"
+                    },
+                    "descriptor": {
+                      "name": "Watermelon",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Watermelon short",
+                      "long_desc": "Watermelon long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd740_0"
+                      ],
+                      "code": "1:2000000000349"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "kilogram",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "46"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "45.00",
+                      "maximum_value": "45.00"
+                    },
+                    "category_id": "Fruits and Vegetables",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M"
+                  },
+                  {
+                    "id": "676a9e1d00d7d9212e3b8f7f",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:59:19.107Z"
+                    },
+                    "descriptor": {
+                      "name": "Apple",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Apple short",
+                      "long_desc": "Apple long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd742_0"
+                      ],
+                      "code": "1:2000000000341"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "kilogram",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "21"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "120.02",
+                      "maximum_value": "120.02"
+                    },
+                    "category_id": "Fruits and Vegetables",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M"
+                  },
+                  {
+                    "id": "676aaa5700d7d9212e3ba019",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:59:19.125Z"
+                    },
+                    "descriptor": {
+                      "name": "Papaya",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Papaya short",
+                      "long_desc": "Papaya long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/67572f250a44cf4e02cdd746_0"
+                      ],
+                      "code": "1:2000000000346"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "kilogram",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "29"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "61.28",
+                      "maximum_value": "64.50"
+                    },
+                    "category_id": "Fruits and Vegetables",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M"
+                  },
+                  {
+                    "id": "676a9fa200d7d9212e3b8fbd",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:59:19.139Z"
+                    },
+                    "descriptor": {
+                      "name": "Beetroot",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Beetroot short",
+                      "long_desc": "Beetroot long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6762dbb841c7aa7c86d1d1c2_0"
+                      ],
+                      "code": "1:2000000000343"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "kilogram",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "0"
+                      },
+                      "maximum": {
+                        "count": "6"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "30.00",
+                      "maximum_value": "30.00"
+                    },
+                    "category_id": "Fruits and Vegetables",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M"
+                  },
+                  {
+                    "id": "676a9f7800d7d9212e3b8fbb",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:59:19.155Z"
+                    },
+                    "descriptor": {
+                      "name": "Beans haricot",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Beans haricot short",
+                      "long_desc": "Beans haricot long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6762dbb841c7aa7c86d1d1c4_0"
+                      ],
+                      "code": "1:2000000000342"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "kilogram",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "0"
+                      },
+                      "maximum": {
+                        "count": "5"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "76.42",
+                      "maximum_value": "78.38"
+                    },
+                    "category_id": "Fruits and Vegetables",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M"
+                  },
+                  {
+                    "id": "676a6126cac4860876a8e309",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:59:19.235Z"
+                    },
+                    "parent_item_id": "V10000000002",
+                    "descriptor": {
+                      "name": "Milk blue",
+                      "symbol": "https://stageapi.lekhha.com/Misc/Images/consumerPhotos/674ecbc6d7b9e10f4210d973",
+                      "short_desc": "Milk blue short",
+                      "long_desc": "Milk blue long",
+                      "images": [
+                        "https://stageapi.lekhha.com/Misc/Images/productImages/6756fced0a44cf4e02cdd6e1_0"
+                      ],
+                      "code": "1:1000000000231"
+                    },
+                    "quantity": {
+                      "unitized": {
+                        "measure": {
+                          "unit": "unit",
+                          "value": "1"
+                        }
+                      },
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "11"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00",
+                      "maximum_value": "40.00"
+                    },
+                    "category_id": "Bakery, Cakes & Dairy",
+                    "fulfillment_id": "1",
+                    "location_id": "674ecbc6d7b9e10f4210d973",
+                    "recommended": false,
+                    "@ondc/org/returnable": true,
+                    "@ondc/org/cancellable": true,
+                    "@ondc/org/seller_pickup_return": true,
+                    "@ondc/org/time_to_ship": "P0DT0H1M",
+                    "@ondc/org/available_on_cod": true,
+                    "@ondc/org/contact_details_consumer_care": "Lekhha_Seller_1 contact person,Lekhha_Seller_1@email1.com,9900025784",
+                    "tags": [
+                      {
+                        "code": "origin",
+                        "list": [
+                          {
+                            "code": "country",
+                            "value": "IND"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "veg_nonveg",
+                        "list": [
+                          {
+                            "code": "non_veg",
+                            "value": "yes"
+                          }
+                        ]
+                      }
+                    ],
+                    "@ondc/org/return_window": "P0DT1H1M",
+                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                      "nutritional_info": "nutri info 8",
+                      "additives_info": "additives info 8",
+                      "brand_owner_FSSAI_license_no": "fssai license 8",
+                      "other_FSSAI_license_no": "other license 8",
+                      "importer_FSSAI_license_no": "importer license 8"
+                    },
+                    "@ondc/org/statutory_reqs_packaged_commodities": {
+                      "manufacturer_or_packer_name": "packer 8",
+                      "manufacturer_or_packer_address": "address 8",
+                      "common_or_generic_name_of_commodity": "commodity 8",
+                      "month_year_of_manufacture_packing_import": "year 8"
+                    }
+                  }
+                ],
+                "locations": [
+                  {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "time": {
+                      "label": "enable",
+                      "timestamp": "2025-04-24T17:59:18.592Z",
+                      "days": "1,2,3,4,5,6,7",
+                      "schedule": {
+                        "holidays": []
+                      },
+                      "range": {
+                        "start": "0001",
+                        "end": "2359"
+                      }
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "locality": "Bengaluru",
+                      "street": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "city": "Bengaluru",
+                      "area_code": "560103",
+                      "state": "KA"
+                    },
+                    "circle": {
+                      "gps": "12.9263841,77.6654374",
+                      "radius": {
+                        "unit": "km",
+                        "value": "999"
+                      }
+                    }
+                  }
+                ],
+                "categories": [
+                  {
+                    "id": "V10000000001",
+                    "descriptor": {
+                      "name": "Variant Group 10000000001"
+                    },
+                    "tags": [
+                      {
+                        "code": "type",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "variant_group"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "attr",
+                        "list": [
+                          {
+                            "code": "name",
+                            "value": "item.quantity.unitized.measure"
+                          },
+                          {
+                            "code": "seq",
+                            "value": "1"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "V10000000002",
+                    "descriptor": {
+                      "name": "Variant Group 10000000002"
+                    },
+                    "tags": [
+                      {
+                        "code": "type",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "variant_group"
+                          }
+                        ]
+                      },
+                      {
+                        "code": "attr",
+                        "list": [
+                          {
+                            "code": "name",
+                            "value": "item.quantity.unitized.measure"
+                          },
+                          {
+                            "code": "seq",
+                            "value": "1"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_select.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_select.json
@@ -1,0 +1,1790 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_select",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "286c6381-431d-4061-9148-2a35b871f258",
+          "timestamp": "2025-04-24T17:59:58.735Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "id": "676a6179cac4860876a8e30b",
+                "quantity": {
+                  "count": 2
+                }
+              },
+              {
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "id": "676a6126cac4860876a8e309",
+                "quantity": {
+                  "count": 3
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate~ns_immediate_f1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "NS_LSP",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "PT55M",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "NS_LSP",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "PT55M",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a7c1748665475e6bf8d0c~19537~YAARI-19537-20250424-HUOK82QSOV~SY-1745517591277-41",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Ecom Express",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a7c1848665475e6bf8d0d~Delhivery~4d58548f-a563-4e12-8994-6687a504e8bf~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Delhivery",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P4D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Immediate Delivery",
+                "@ondc/org/TAT": "PT60M",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~37260627-31f5-461f-b01c-67c16a6b69b3",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Express Delivery",
+                "@ondc/org/TAT": "P1D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~5476be14-c110-4772-a03b-8d28924827bc",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Next Day Delivery",
+                "@ondc/org/TAT": "P1D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~ed4b869a-0023-4bcf-a533-a0536667b63f",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Same Day Delivery",
+                "@ondc/org/TAT": "PT4H",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a7c1848665475e6bf8d11~MOVERDELIVERY~I1~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Mover",
+                "tracking": false,
+                "@ondc/org/category": "Immediate Delivery",
+                "@ondc/org/TAT": "PT30M",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a7c1848665475e6bf8d15~P1~I1~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Bharat Mart",
+                "tracking": false,
+                "@ondc/org/category": "Immediate Delivery",
+                "@ondc/org/TAT": "PT60M",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a7c1948665475e6bf8d16~Bluedart Express~BDEEP0~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Bluedart Express",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P4D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a7c1948665475e6bf8d17~P1~I1~I1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "Exeed Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P8D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              },
+              {
+                "id": "680a7c1948665475e6bf8d18~DTDC~B2C SMART EXPRESS~1",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "DTDC",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P4D",
+                "state": {
+                  "descriptor": {
+                    "code": "Serviceable"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1 legal"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "129654.47"
+              },
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "quantity": {
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "12"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "quantity": {
+                      "available": {
+                        "count": "99"
+                      },
+                      "maximum": {
+                        "count": "11"
+                      }
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "2.0"
+                  },
+                  "lsp_provider_id": "NS_LSP",
+                  "lsp_fulfillment_id": "ns_immediate_f1",
+                  "lsp_item_details": {
+                    "id": "ns_immediate",
+                    "parent_item_id": "",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "ns_immediate_f1",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "NS LSP Immediate Delivery",
+                      "short_desc": "Immediate Delivery by NS LSP",
+                      "long_desc": "Immediate Delivery by NS LSP"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "2.0"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT55M",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  },
+                  "lsp_provider_id": "NS_LSP",
+                  "lsp_fulfillment_id": "ns_immediate_f1-RTO",
+                  "lsp_item_details": {
+                    "id": "ns_immediate-RTO",
+                    "parent_item_id": "ns_immediate",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "ns_immediate_f1-RTO",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "RTO quote",
+                      "short_desc": "RTO quote",
+                      "long_desc": "RTO quote"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "0"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT55M",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1748665475e6bf8d0c~19537~YAARI-19537-20250424-HUOK82QSOV~SY-1745517591277-41",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "395.74"
+                  },
+                  "lsp_provider_id": "19537",
+                  "lsp_fulfillment_id": "SY-1745517591277-41",
+                  "lsp_item_details": {
+                    "id": "YAARI-19537-20250424-HUOK82QSOV",
+                    "parent_item_id": "",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "SY-1745517591277-41",
+                    "descriptor": {
+                      "code": "P2H2P",
+                      "name": "Ecom Express",
+                      "short_desc": "Ecom Express",
+                      "long_desc": "Ecom Express"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "395.74"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0d~Delhivery~4d58548f-a563-4e12-8994-6687a504e8bf~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "7500.72"
+                  },
+                  "lsp_provider_id": "Delhivery",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "4d58548f-a563-4e12-8994-6687a504e8bf",
+                    "parent_item_id": "",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "1",
+                    "descriptor": {
+                      "code": "P2H2P",
+                      "name": "Standard Delivery",
+                      "short_desc": "Delhivery Surface",
+                      "long_desc": "Delhivery Surface"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "7500.72"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P4D",
+                      "timestamp": "2025-04-28"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                  "lsp_item_details": {
+                    "id": "imd_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Immediate Delivery",
+                      "long_desc": "Upto 60 mins for Delivery",
+                      "short_desc": "Upto 60 mins for Delivery"
+                    },
+                    "category_id": "Immediate Delivery",
+                    "fulfillment_id": "8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~37260627-31f5-461f-b01c-67c16a6b69b3",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "37260627-31f5-461f-b01c-67c16a6b69b3",
+                  "lsp_item_details": {
+                    "id": "exp_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Express Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Express Delivery",
+                    "fulfillment_id": "37260627-31f5-461f-b01c-67c16a6b69b3",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~5476be14-c110-4772-a03b-8d28924827bc",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "5476be14-c110-4772-a03b-8d28924827bc",
+                  "lsp_item_details": {
+                    "id": "nex_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Next Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Next Day Delivery",
+                    "fulfillment_id": "5476be14-c110-4772-a03b-8d28924827bc",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~ed4b869a-0023-4bcf-a533-a0536667b63f",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "ed4b869a-0023-4bcf-a533-a0536667b63f",
+                  "lsp_item_details": {
+                    "id": "same_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Same Day Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Same Day Delivery",
+                    "fulfillment_id": "ed4b869a-0023-4bcf-a533-a0536667b63f",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT4H",
+                      "timestamp": "2025-04-24"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d11~MOVERDELIVERY~I1~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "25527"
+                  },
+                  "lsp_provider_id": "MOVERDELIVERY",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "I1",
+                    "parent_item_id": "",
+                    "category_id": "Immediate Delivery",
+                    "fulfillment_id": "1",
+                    "descriptor": {
+                      "name": "30 min delivery",
+                      "short_desc": "30 min delivery for F&B",
+                      "long_desc": "30 min delivery for F&B",
+                      "code": "P2P"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "25527"
+                    },
+                    "time": {
+                      "duration": "PT30M",
+                      "label": "TAT",
+                      "timestamp": "2025-04-24T17:59:51.9839819Z"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d15~P1~I1~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "59.00"
+                  },
+                  "lsp_provider_id": "P1",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "I1",
+                    "parent_item_id": "",
+                    "category_id": "Immediate Delivery",
+                    "fulfillment_id": "1",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "60 min delivery",
+                      "short_desc": "60 min delivery for F&B",
+                      "long_desc": "60 min delivery for F&B"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "59.00"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "PT60M",
+                      "timestamp": "2023-06-06"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1948665475e6bf8d16~Bluedart Express~BDEEP0~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "1388.29"
+                  },
+                  "lsp_provider_id": "Bluedart Express",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "BDEEP0",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "1",
+                    "descriptor": {
+                      "name": "Dart Surface Etail",
+                      "code": "P2H2P",
+                      "short_desc": "Standard Delivery",
+                      "long_desc": "Standard Delivery"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "timestamp": "2025-04-28",
+                      "duration": "P4D"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "1388.29"
+                    },
+                    "parent_item_id": ""
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1948665475e6bf8d17~P1~I1~I1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "65560.00"
+                  },
+                  "lsp_provider_id": "P1",
+                  "lsp_fulfillment_id": "I1",
+                  "lsp_item_details": {
+                    "id": "I1",
+                    "parent_item_id": "",
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "I1",
+                    "descriptor": {
+                      "code": "P2H2P",
+                      "name": "Standard",
+                      "short_desc": "Standard",
+                      "long_desc": "Standard"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "65560.00"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P8D",
+                      "timestamp": "2025-04-24T17:59:53.494904Z"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1948665475e6bf8d18~DTDC~B2C SMART EXPRESS~1",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "815.00"
+                  },
+                  "lsp_provider_id": "DTDC",
+                  "lsp_fulfillment_id": "1",
+                  "lsp_item_details": {
+                    "id": "B2C SMART EXPRESS",
+                    "category_id": "Standard Delivery",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2H2P",
+                      "name": "Standard Delivery",
+                      "short_desc": "B2C SMART EXPRESS",
+                      "long_desc": "3 - 4 Day/s"
+                    },
+                    "price": {
+                      "currency": "INR",
+                      "value": "815.00"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P4D",
+                      "timestamp": "2025-04-28"
+                    },
+                    "fulfillment_id": "1"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate~ns_immediate_f1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1748665475e6bf8d0b~NS_LSP~ns_immediate-RTO~ns_immediate_f1-RTO",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1748665475e6bf8d0c~19537~YAARI-19537-20250424-HUOK82QSOV~SY-1745517591277-41",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1748665475e6bf8d0c~19537~YAARI-19537-20250424-HUOK82QSOV~SY-1745517591277-41",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1748665475e6bf8d0c~19537~YAARI-19537-20250424-HUOK82QSOV~SY-1745517591277-41",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0d~Delhivery~4d58548f-a563-4e12-8994-6687a504e8bf~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0d~Delhivery~4d58548f-a563-4e12-8994-6687a504e8bf~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0d~Delhivery~4d58548f-a563-4e12-8994-6687a504e8bf~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~imd_del~8c8692d9-ef5c-449f-8c53-512167b0e33b",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~37260627-31f5-461f-b01c-67c16a6b69b3",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~37260627-31f5-461f-b01c-67c16a6b69b3",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~exp_del~37260627-31f5-461f-b01c-67c16a6b69b3",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~5476be14-c110-4772-a03b-8d28924827bc",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~5476be14-c110-4772-a03b-8d28924827bc",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~nex_del~5476be14-c110-4772-a03b-8d28924827bc",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~ed4b869a-0023-4bcf-a533-a0536667b63f",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~ed4b869a-0023-4bcf-a533-a0536667b63f",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~same_del~ed4b869a-0023-4bcf-a533-a0536667b63f",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d11~MOVERDELIVERY~I1~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d11~MOVERDELIVERY~I1~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d11~MOVERDELIVERY~I1~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d15~P1~I1~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d15~P1~I1~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d15~P1~I1~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1948665475e6bf8d16~Bluedart Express~BDEEP0~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1948665475e6bf8d16~Bluedart Express~BDEEP0~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1948665475e6bf8d16~Bluedart Express~BDEEP0~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1948665475e6bf8d17~P1~I1~I1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1948665475e6bf8d17~P1~I1~I1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1948665475e6bf8d17~P1~I1~I1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1948665475e6bf8d18~DTDC~B2C SMART EXPRESS~1",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1948665475e6bf8d18~DTDC~B2C SMART EXPRESS~1",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1948665475e6bf8d18~DTDC~B2C SMART EXPRESS~1",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "ttl": "P1D"
+            },
+            "tags": [
+              {
+                "code": "bpp_terms",
+                "list": [
+                  {
+                    "code": "accept_bap_terms",
+                    "value": "Y"
+                  },
+                  {
+                    "code": "np_type",
+                    "value": "MSN"
+                  },
+                  {
+                    "code": "collect_payment",
+                    "value": "Y"
+                  },
+                  {
+                    "code": "max_liability",
+                    "value": "2"
+                  },
+                  {
+                    "code": "max_liability_cap",
+                    "value": "10000"
+                  },
+                  {
+                    "code": "mandatory_arbitration",
+                    "value": "false"
+                  },
+                  {
+                    "code": "court_jurisdiction",
+                    "value": "Bengaluru"
+                  },
+                  {
+                    "code": "delay_interest",
+                    "value": "7"
+                  },
+                  {
+                    "code": "tax_number",
+                    "value": "29ABGCS7802J1ZX"
+                  },
+                  {
+                    "code": "provider_tax_number",
+                    "value": "ABGCS7802J"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_status_1_accepted.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_status_1_accepted.json
@@ -1,0 +1,312 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "91810c78-abe5-4af3-ad38-6297d126c28f",
+          "timestamp": "2025-04-24T18:01:07.326Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "Accepted",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "tracking": false,
+                "@ondc/org/category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D",
+                "start": {
+                  "location": {
+                    "id": "674ecbc6d7b9e10f4210d973",
+                    "descriptor": {
+                      "name": "Lekhha_Seller_1"
+                    },
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "street": "",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": "other pickup confirmation code",
+                    "long_desc": "Pls pickup orders from counter number 01."
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-24T17:30:00.000Z",
+                      "end": "2025-04-24T19:30:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "instructions": {
+                    "name": "Proof of delivery",
+                    "code": "3",
+                    "short_desc": "no delivery code",
+                    "long_desc": ""
+                  },
+                  "time": {
+                    "range": {
+                      "end": "2025-04-24T18:03:43.679Z"
+                    }
+                  }
+                },
+                "state": {
+                  "descriptor": {
+                    "code": "Pending",
+                    "name": "Getting ready for shipment (packaging)"
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:01:07.264Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_status_2_packed.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_status_2_packed.json
@@ -1,0 +1,294 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "409d3e03-bb03-4842-bcfb-504c8ed74458",
+          "timestamp": "2025-04-24T18:01:20.442Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Packed",
+                    "name": "Packaging completed. Ready to ship"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:01:07.264Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_status_3_agent_assigned.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_status_3_agent_assigned.json
@@ -1,0 +1,302 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "1789f17a-cba4-4634-821b-8c7172fb80ea",
+          "timestamp": "2025-04-24T18:01:29.626Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Agent-assigned",
+                    "name": "Agent assigned"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    }
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:01:07.264Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_status_4_picked_up.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_status_4_picked_up.json
@@ -1,0 +1,309 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "9a043075-de5e-4542-8101-713f535b4a70",
+          "timestamp": "2025-04-24T18:01:35.757Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-picked-up",
+                    "name": "Product picked up from the source and shipment started"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:01:35.578Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:01:07.264Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_status_5_out_for_delivery.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_status_5_out_for_delivery.json
@@ -1,0 +1,309 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "ab702c07-22ba-4b74-b870-2c63e38e22ed",
+          "timestamp": "2025-04-24T18:01:41.759Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Out-for-delivery",
+                    "name": "Product would be delivered soon"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:01:35.578Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:01:07.264Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_status_6_response.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_status_6_response.json
@@ -1,0 +1,309 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "202480a7-a343-403f-8d50-0e527bd9f4ba",
+          "timestamp": "2025-04-24T18:02:09.208Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "In-progress",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Out-for-delivery",
+                    "name": "Product would be delivered soon"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:01:35.578Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    }
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:01:07.264Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_status_7_delivered.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_status_7_delivered.json
@@ -1,0 +1,316 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_status",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "eeb2c0b9-d0e8-4241-bc00-d117355a0646",
+          "timestamp": "2025-04-24T18:02:23.636Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "Completed",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-delivered",
+                    "name": "Product delivered"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:01:35.578Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:02:23.474Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Delivery",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:01:07.264Z"
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_update_1_return_initiated.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_update_1_return_initiated.json
@@ -1,0 +1,525 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_update",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "b700e0f6-b2e7-4eae-8bbe-55c91b27cc2d",
+          "timestamp": "2025-04-24T18:02:52.757Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "Completed",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-delivered",
+                    "name": "Product delivered"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:01:35.578Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:02:23.474Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Delivery",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              },
+              {
+                "id": "ce69a8d9-e7b9-4f64-8879-8dffe2783019",
+                "type": "Return",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "state": {
+                  "descriptor": {
+                    "code": "Return_Initiated",
+                    "name": "Return request is received"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": "other pickup confirmation code"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of delivery",
+                    "code": "3",
+                    "short_desc": "no delivery code"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "return_request",
+                    "list": [
+                      {
+                        "code": "id",
+                        "value": "ce69a8d9-e7b9-4f64-8879-8dffe2783019"
+                      },
+                      {
+                        "code": "item_id",
+                        "value": "676a6179cac4860876a8e30b"
+                      },
+                      {
+                        "code": "item_quantity",
+                        "value": "2"
+                      },
+                      {
+                        "code": "reason_id",
+                        "value": "003"
+                      },
+                      {
+                        "code": "reason_desc",
+                        "value": "some detailed reason for return"
+                      },
+                      {
+                        "code": "images",
+                        "value": "https://some-images-for-item.com"
+                      },
+                      {
+                        "code": "ttl_approval",
+                        "value": "PT24H"
+                      },
+                      {
+                        "code": "ttl_reverseqc",
+                        "value": "P3D"
+                      },
+                      {
+                        "code": "initiated_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                      }
+                    ]
+                  }
+                ],
+                "category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D"
+              },
+              {
+                "id": "9f4b8ecb-8389-4034-98f1-f371436e1e4e",
+                "type": "Return",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "state": {
+                  "descriptor": {
+                    "code": "Return_Initiated",
+                    "name": "Return request is received"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": "other pickup confirmation code"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of delivery",
+                    "code": "3",
+                    "short_desc": "no delivery code"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "return_request",
+                    "list": [
+                      {
+                        "code": "id",
+                        "value": "9f4b8ecb-8389-4034-98f1-f371436e1e4e"
+                      },
+                      {
+                        "code": "item_id",
+                        "value": "676a6126cac4860876a8e309"
+                      },
+                      {
+                        "code": "item_quantity",
+                        "value": "3"
+                      },
+                      {
+                        "code": "reason_id",
+                        "value": "003"
+                      },
+                      {
+                        "code": "reason_desc",
+                        "value": "some detailed reason for return"
+                      },
+                      {
+                        "code": "images",
+                        "value": "https://some-images-for-item.com"
+                      },
+                      {
+                        "code": "ttl_approval",
+                        "value": "PT24H"
+                      },
+                      {
+                        "code": "ttl_reverseqc",
+                        "value": "P3D"
+                      },
+                      {
+                        "code": "initiated_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                      }
+                    ]
+                  }
+                ],
+                "category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D"
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:02:52.757Z",
+            "documents": [
+              {
+                "url": "https://stageapi.lekhha.com/Misc/Invoice/productImages/680a7c3948665475e6bf8d27.pdf",
+                "label": "Invoice"
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_update_2_return_approved.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_update_2_return_approved.json
@@ -1,0 +1,525 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_update",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "6609982d-25c4-45b3-aa0e-09d66d30187b",
+          "timestamp": "2025-04-24T18:03:41.586Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "Completed",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-delivered",
+                    "name": "Product delivered"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:01:35.578Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:02:23.474Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Delivery",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              },
+              {
+                "id": "ce69a8d9-e7b9-4f64-8879-8dffe2783019",
+                "type": "Return",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "state": {
+                  "descriptor": {
+                    "code": "Return_Approved",
+                    "name": "Return request approved"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": ""
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of delivery",
+                    "code": "3",
+                    "short_desc": "no delivery code"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "return_request",
+                    "list": [
+                      {
+                        "code": "id",
+                        "value": "ce69a8d9-e7b9-4f64-8879-8dffe2783019"
+                      },
+                      {
+                        "code": "item_id",
+                        "value": "676a6179cac4860876a8e30b"
+                      },
+                      {
+                        "code": "item_quantity",
+                        "value": "2"
+                      },
+                      {
+                        "code": "reason_id",
+                        "value": "003"
+                      },
+                      {
+                        "code": "reason_desc",
+                        "value": "some detailed reason for return"
+                      },
+                      {
+                        "code": "images",
+                        "value": "https://some-images-for-item.com"
+                      },
+                      {
+                        "code": "ttl_approval",
+                        "value": "PT24H"
+                      },
+                      {
+                        "code": "ttl_reverseqc",
+                        "value": "P3D"
+                      },
+                      {
+                        "code": "initiated_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                      }
+                    ]
+                  }
+                ],
+                "category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D"
+              },
+              {
+                "id": "9f4b8ecb-8389-4034-98f1-f371436e1e4e",
+                "type": "Return",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "state": {
+                  "descriptor": {
+                    "code": "Return_Approved",
+                    "name": "Return request approved"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": ""
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of delivery",
+                    "code": "3",
+                    "short_desc": "no delivery code"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "return_request",
+                    "list": [
+                      {
+                        "code": "id",
+                        "value": "9f4b8ecb-8389-4034-98f1-f371436e1e4e"
+                      },
+                      {
+                        "code": "item_id",
+                        "value": "676a6126cac4860876a8e309"
+                      },
+                      {
+                        "code": "item_quantity",
+                        "value": "3"
+                      },
+                      {
+                        "code": "reason_id",
+                        "value": "003"
+                      },
+                      {
+                        "code": "reason_desc",
+                        "value": "some detailed reason for return"
+                      },
+                      {
+                        "code": "images",
+                        "value": "https://some-images-for-item.com"
+                      },
+                      {
+                        "code": "ttl_approval",
+                        "value": "PT24H"
+                      },
+                      {
+                        "code": "ttl_reverseqc",
+                        "value": "P3D"
+                      },
+                      {
+                        "code": "initiated_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                      }
+                    ]
+                  }
+                ],
+                "category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D"
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "6191.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 2
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "800.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "-40.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 3
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "120.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:03:41.586Z",
+            "documents": [
+              {
+                "url": "https://stageapi.lekhha.com/Misc/Invoice/productImages/680a7c3948665475e6bf8d27.pdf",
+                "label": "Invoice"
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_update_3_return_picked.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_update_3_return_picked.json
@@ -1,0 +1,629 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_update",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "479b8276-9aab-4da1-afe9-8ea30cee538f",
+          "timestamp": "2025-04-24T18:05:08.542Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "Completed",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 0
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 0
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "fulfillment_id": "ce69a8d9-e7b9-4f64-8879-8dffe2783019",
+                "quantity": {
+                  "count": 2
+                }
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "fulfillment_id": "9f4b8ecb-8389-4034-98f1-f371436e1e4e",
+                "quantity": {
+                  "count": 3
+                }
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-delivered",
+                    "name": "Product delivered"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:01:35.578Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:02:23.474Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Delivery",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              },
+              {
+                "id": "ce69a8d9-e7b9-4f64-8879-8dffe2783019",
+                "type": "Return",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "state": {
+                  "descriptor": {
+                    "code": "Return_Picked",
+                    "name": "Reverse QC is initiated"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": ""
+                  },
+                  "time": {
+                    "timestamp": "2025-04-24T18:05:08.511Z"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of delivery",
+                    "code": "3",
+                    "short_desc": "no delivery code"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "return_request",
+                    "list": [
+                      {
+                        "code": "id",
+                        "value": "ce69a8d9-e7b9-4f64-8879-8dffe2783019"
+                      },
+                      {
+                        "code": "item_id",
+                        "value": "676a6179cac4860876a8e30b"
+                      },
+                      {
+                        "code": "item_quantity",
+                        "value": "2"
+                      },
+                      {
+                        "code": "reason_id",
+                        "value": "003"
+                      },
+                      {
+                        "code": "reason_desc",
+                        "value": "some detailed reason for return"
+                      },
+                      {
+                        "code": "images",
+                        "value": "https://some-images-for-item.com"
+                      },
+                      {
+                        "code": "ttl_approval",
+                        "value": "PT24H"
+                      },
+                      {
+                        "code": "ttl_reverseqc",
+                        "value": "P3D"
+                      },
+                      {
+                        "code": "initiated_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "quote_trail",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "item"
+                      },
+                      {
+                        "code": "id",
+                        "value": "676a6179cac4860876a8e30b"
+                      },
+                      {
+                        "code": "currency",
+                        "value": "INR"
+                      },
+                      {
+                        "code": "value",
+                        "value": "-800.00"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "quote_trail",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "discount"
+                      },
+                      {
+                        "code": "id",
+                        "value": "676a6179cac4860876a8e30b"
+                      },
+                      {
+                        "code": "currency",
+                        "value": "INR"
+                      },
+                      {
+                        "code": "value",
+                        "value": "40.00"
+                      }
+                    ]
+                  }
+                ],
+                "category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D"
+              },
+              {
+                "id": "9f4b8ecb-8389-4034-98f1-f371436e1e4e",
+                "type": "Return",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "state": {
+                  "descriptor": {
+                    "code": "Return_Picked",
+                    "name": "Reverse QC is initiated"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": ""
+                  },
+                  "time": {
+                    "timestamp": "2025-04-24T18:05:08.531Z"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of delivery",
+                    "code": "3",
+                    "short_desc": "no delivery code"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "return_request",
+                    "list": [
+                      {
+                        "code": "id",
+                        "value": "9f4b8ecb-8389-4034-98f1-f371436e1e4e"
+                      },
+                      {
+                        "code": "item_id",
+                        "value": "676a6126cac4860876a8e309"
+                      },
+                      {
+                        "code": "item_quantity",
+                        "value": "3"
+                      },
+                      {
+                        "code": "reason_id",
+                        "value": "003"
+                      },
+                      {
+                        "code": "reason_desc",
+                        "value": "some detailed reason for return"
+                      },
+                      {
+                        "code": "images",
+                        "value": "https://some-images-for-item.com"
+                      },
+                      {
+                        "code": "ttl_approval",
+                        "value": "PT24H"
+                      },
+                      {
+                        "code": "ttl_reverseqc",
+                        "value": "P3D"
+                      },
+                      {
+                        "code": "initiated_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "quote_trail",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "item"
+                      },
+                      {
+                        "code": "id",
+                        "value": "676a6126cac4860876a8e309"
+                      },
+                      {
+                        "code": "currency",
+                        "value": "INR"
+                      },
+                      {
+                        "code": "value",
+                        "value": "-120.00"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "quote_trail",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "discount"
+                      },
+                      {
+                        "code": "id",
+                        "value": "676a6126cac4860876a8e309"
+                      },
+                      {
+                        "code": "currency",
+                        "value": "INR"
+                      },
+                      {
+                        "code": "value",
+                        "value": "0.00"
+                      }
+                    ]
+                  }
+                ],
+                "category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D"
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5311.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 0
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 0
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:05:08.542Z",
+            "documents": [
+              {
+                "url": "https://stageapi.lekhha.com/Misc/Invoice/productImages/680a7c3948665475e6bf8d27.pdf",
+                "label": "Invoice"
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_update_4_return_delivered.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_on_update_4_return_delivered.json
@@ -1,0 +1,635 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "on_update",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "f7374856-d520-4258-9429-487b11f5ec5c",
+          "timestamp": "2025-04-24T18:05:24.980Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "id": "SS1745517638223",
+            "state": "Completed",
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 0
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 0
+                },
+                "fulfillment_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a"
+              },
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "fulfillment_id": "ce69a8d9-e7b9-4f64-8879-8dffe2783019",
+                "quantity": {
+                  "count": 2
+                }
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "fulfillment_id": "9f4b8ecb-8389-4034-98f1-f371436e1e4e",
+                "quantity": {
+                  "count": 3
+                }
+              }
+            ],
+            "billing": {
+              "address": {
+                "name": "Nirdosh Chauhan",
+                "building": "221 B",
+                "locality": "Baker Steeet",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "country": "India",
+                "area_code": "122007"
+              },
+              "tax_number": "00ABCDE1234F1Z5",
+              "name": "Nirdosh Chauhan",
+              "email": "nirdosh.chauhan@sequelstring.com",
+              "phone": "9876543210",
+              "created_at": "2025-04-24T18:00:22.623Z",
+              "updated_at": "2025-04-24T18:00:22.623Z"
+            },
+            "fulfillments": [
+              {
+                "id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                "type": "Delivery",
+                "state": {
+                  "descriptor": {
+                    "code": "Order-delivered",
+                    "name": "Product delivered"
+                  }
+                },
+                "tracking": true,
+                "start": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "time": {
+                    "duration": "P0DT0H1M",
+                    "range": {
+                      "start": "2025-04-24T09:00:00.000Z",
+                      "end": "2025-04-24T23:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:01:35.578Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Pickup",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    }
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "time": {
+                    "range": {
+                      "start": "2025-04-25T09:30:00.000Z",
+                      "end": "2025-04-25T19:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-24T18:02:23.474Z"
+                  },
+                  "instructions": {
+                    "name": "Proof Of Delivery",
+                    "images": [
+                      "http://sequelstring-lsp-ondc.com/proof"
+                    ]
+                  }
+                },
+                "tags": null,
+                "agent": {
+                  "name": "Tom Hagen",
+                  "phone": "9876543210"
+                },
+                "vehicle": {
+                  "registration": "3LVJ945"
+                }
+              },
+              {
+                "id": "ce69a8d9-e7b9-4f64-8879-8dffe2783019",
+                "type": "Return",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "state": {
+                  "descriptor": {
+                    "code": "Return_Delivered",
+                    "name": "Return is delivered to the merchant location"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": ""
+                  },
+                  "time": {
+                    "timestamp": "2025-04-24T18:05:08.511Z"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of delivery",
+                    "code": "3",
+                    "short_desc": "no delivery code"
+                  },
+                  "time": {
+                    "timestamp": "2025-04-24T18:05:24.958Z"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "return_request",
+                    "list": [
+                      {
+                        "code": "id",
+                        "value": "ce69a8d9-e7b9-4f64-8879-8dffe2783019"
+                      },
+                      {
+                        "code": "item_id",
+                        "value": "676a6179cac4860876a8e30b"
+                      },
+                      {
+                        "code": "item_quantity",
+                        "value": "2"
+                      },
+                      {
+                        "code": "reason_id",
+                        "value": "003"
+                      },
+                      {
+                        "code": "reason_desc",
+                        "value": "some detailed reason for return"
+                      },
+                      {
+                        "code": "images",
+                        "value": "https://some-images-for-item.com"
+                      },
+                      {
+                        "code": "ttl_approval",
+                        "value": "PT24H"
+                      },
+                      {
+                        "code": "ttl_reverseqc",
+                        "value": "P3D"
+                      },
+                      {
+                        "code": "initiated_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "quote_trail",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "item"
+                      },
+                      {
+                        "code": "id",
+                        "value": "676a6179cac4860876a8e30b"
+                      },
+                      {
+                        "code": "currency",
+                        "value": "INR"
+                      },
+                      {
+                        "code": "value",
+                        "value": "-800.00"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "quote_trail",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "discount"
+                      },
+                      {
+                        "code": "id",
+                        "value": "676a6179cac4860876a8e30b"
+                      },
+                      {
+                        "code": "currency",
+                        "value": "INR"
+                      },
+                      {
+                        "code": "value",
+                        "value": "40.00"
+                      }
+                    ]
+                  }
+                ],
+                "category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D"
+              },
+              {
+                "id": "9f4b8ecb-8389-4034-98f1-f371436e1e4e",
+                "type": "Return",
+                "@ondc/org/provider_name": "ONDC Pramaaan Logistics",
+                "state": {
+                  "descriptor": {
+                    "code": "Return_Delivered",
+                    "name": "Return is delivered to the merchant location"
+                  }
+                },
+                "start": {
+                  "location": {
+                    "address": {
+                      "name": "Nirdosh Chauhan",
+                      "building": "221 B",
+                      "locality": "Baker Steeet",
+                      "city": "Gurgaon",
+                      "state": "Haryana",
+                      "country": "India",
+                      "area_code": "122007"
+                    },
+                    "gps": "28.4554726,77.0219019"
+                  },
+                  "contact": {
+                    "phone": "9876543210",
+                    "email": "nirdosh.chauhan@sequelstring.com"
+                  },
+                  "instructions": {
+                    "name": "Proof of pickup",
+                    "code": "3",
+                    "short_desc": ""
+                  },
+                  "time": {
+                    "timestamp": "2025-04-24T18:05:08.531Z"
+                  }
+                },
+                "end": {
+                  "location": {
+                    "gps": "12.9263841,77.6654374",
+                    "address": {
+                      "name": "Lekhha_Seller_1",
+                      "building": "WMG8+H5, SUNCITY APARTMENT-1",
+                      "locality": "Bengaluru",
+                      "city": "Bengaluru",
+                      "state": "KA",
+                      "country": "IND",
+                      "area_code": "560103"
+                    }
+                  },
+                  "contact": {
+                    "email": "Lekhha_Seller_1@email1.com",
+                    "phone": "9900025784"
+                  },
+                  "instructions": {
+                    "name": "Proof of delivery",
+                    "code": "3",
+                    "short_desc": "no delivery code"
+                  },
+                  "time": {
+                    "timestamp": "2025-04-24T18:05:24.976Z"
+                  }
+                },
+                "tags": [
+                  {
+                    "code": "return_request",
+                    "list": [
+                      {
+                        "code": "id",
+                        "value": "9f4b8ecb-8389-4034-98f1-f371436e1e4e"
+                      },
+                      {
+                        "code": "item_id",
+                        "value": "676a6126cac4860876a8e309"
+                      },
+                      {
+                        "code": "item_quantity",
+                        "value": "3"
+                      },
+                      {
+                        "code": "reason_id",
+                        "value": "003"
+                      },
+                      {
+                        "code": "reason_desc",
+                        "value": "some detailed reason for return"
+                      },
+                      {
+                        "code": "images",
+                        "value": "https://some-images-for-item.com"
+                      },
+                      {
+                        "code": "ttl_approval",
+                        "value": "PT24H"
+                      },
+                      {
+                        "code": "ttl_reverseqc",
+                        "value": "P3D"
+                      },
+                      {
+                        "code": "initiated_by",
+                        "value": "pramaan.ondc.org/beta/preprod/mock/buyer"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "quote_trail",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "item"
+                      },
+                      {
+                        "code": "id",
+                        "value": "676a6126cac4860876a8e309"
+                      },
+                      {
+                        "code": "currency",
+                        "value": "INR"
+                      },
+                      {
+                        "code": "value",
+                        "value": "-120.00"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "quote_trail",
+                    "list": [
+                      {
+                        "code": "type",
+                        "value": "discount"
+                      },
+                      {
+                        "code": "id",
+                        "value": "676a6126cac4860876a8e309"
+                      },
+                      {
+                        "code": "currency",
+                        "value": "INR"
+                      },
+                      {
+                        "code": "value",
+                        "value": "0.00"
+                      }
+                    ]
+                  }
+                ],
+                "category": "Standard Delivery",
+                "@ondc/org/TAT": "P1D"
+              }
+            ],
+            "quote": {
+              "price": {
+                "currency": "INR",
+                "value": "5311.70"
+              },
+              "ttl": "P1D",
+              "breakup": [
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "@ondc/org/item_quantity": {
+                    "count": 0
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "400.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6179cac4860876a8e30b",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "@ondc/org/item_quantity": {
+                    "count": 0
+                  },
+                  "title": "Milk blue",
+                  "@ondc/org/title_type": "item",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                  },
+                  "item": {
+                    "price": {
+                      "currency": "INR",
+                      "value": "40.00"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "676a6126cac4860876a8e309",
+                  "title": "Discount",
+                  "@ondc/org/title_type": "discount",
+                  "price": {
+                    "currency": "INR",
+                    "value": "0"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Delivery charges",
+                  "@ondc/org/title_type": "delivery",
+                  "price": {
+                    "currency": "INR",
+                    "value": "5204.12"
+                  },
+                  "lsp_provider_id": "b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c",
+                  "lsp_fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "lsp_item_details": {
+                    "id": "std_del",
+                    "parent_item_id": "",
+                    "descriptor": {
+                      "code": "P2P",
+                      "name": "Standard Delivery",
+                      "long_desc": "Upto 1 day for Delivery",
+                      "short_desc": "Upto 1 day for Delivery"
+                    },
+                    "category_id": "Standard Delivery",
+                    "fulfillment_id": "879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                    "price": {
+                      "currency": "INR",
+                      "value": "5204.12"
+                    },
+                    "time": {
+                      "label": "TAT",
+                      "duration": "P1D",
+                      "timestamp": "2025-04-25"
+                    }
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Packing charges",
+                  "@ondc/org/title_type": "packing",
+                  "price": {
+                    "currency": "INR",
+                    "value": "33"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Convenience Fee",
+                  "@ondc/org/title_type": "misc",
+                  "price": {
+                    "currency": "INR",
+                    "value": "66.44"
+                  }
+                },
+                {
+                  "@ondc/org/item_id": "680a7c1848665475e6bf8d0e~b2e91c9b-6c3a-4b22-86d9-e09ae76bc11c~std_del~879bb063-00a0-4e26-bf9b-d6fa55a7952a",
+                  "title": "Tax",
+                  "@ondc/org/title_type": "tax",
+                  "price": {
+                    "currency": "INR",
+                    "value": "8.14"
+                  },
+                  "item": {
+                    "tags": [
+                      {
+                        "code": "quote",
+                        "list": [
+                          {
+                            "code": "type",
+                            "value": "fulfillment"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "payment": {
+              "type": "ON-ORDER",
+              "params": {
+                "amount": "6191.70",
+                "currency": "INR",
+                "transaction_id": "a540d65b-ceea-4596-818c-a55c9529ad99"
+              },
+              "status": "PAID",
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3",
+              "@ondc/org/settlement_basis": "delivery",
+              "@ondc/org/settlement_window": "P1D",
+              "@ondc/org/withholding_amount": "10.00",
+              "@ondc/org/collected_by_status": "Agree",
+              "collected_by": "BAP",
+              "@ondc/org/settlement_details": [
+                {
+                  "settlement_counterparty": "seller-app",
+                  "settlement_phase": "sale-amount",
+                  "settlement_type": "upi",
+                  "beneficiary_name": "Lekhha NP",
+                  "upi_address": "testLekhhaup.com",
+                  "settlement_bank_account_no": "testLekhhaBankAcc",
+                  "settlement_ifsc_code": "testLekhhaIfsc",
+                  "bank_name": "testLekhhaBank",
+                  "branch_name": "testLekhhaBranch"
+                }
+              ]
+            },
+            "created_at": "2025-04-24T18:00:38.223Z",
+            "updated_at": "2025-04-24T18:05:24.980Z",
+            "documents": [
+              {
+                "url": "https://stageapi.lekhha.com/Misc/Invoice/productImages/680a7c3948665475e6bf8d27.pdf",
+                "label": "Invoice"
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_search.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_search.json
@@ -1,0 +1,34 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "search",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "2b720846-83aa-4fbd-af77-a819833111c8",
+          "timestamp": "2025-04-24T17:59:15.243Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "intent": {
+            "payment": {
+              "@ondc/org/buyer_app_finder_fee_type": "percent",
+              "@ondc/org/buyer_app_finder_fee_amount": "3"
+            },
+            "tags": [
+              {
+                "code": "catalog_full",
+                "list": [
+                  {
+                    "code": "payload_type",
+                    "value": "inline"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_select.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_select.json
@@ -1,0 +1,60 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "select",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "286c6381-431d-4061-9148-2a35b871f258",
+          "timestamp": "2025-04-24T17:59:50.562Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "ttl": "PT30S",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1"
+        },
+        "message": {
+          "order": {
+            "provider": {
+              "id": "674ecb33d7b9e10f4210d972",
+              "locations": [
+                {
+                  "id": "674ecbc6d7b9e10f4210d973"
+                }
+              ]
+            },
+            "items": [
+              {
+                "id": "676a6179cac4860876a8e30b",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 2
+                }
+              },
+              {
+                "id": "676a6126cac4860876a8e309",
+                "location_id": "674ecbc6d7b9e10f4210d973",
+                "quantity": {
+                  "count": 3
+                }
+              }
+            ],
+            "fulfillments": [
+              {
+                "end": {
+                  "location": {
+                    "gps": "28.4554726,77.0219019",
+                    "address": {
+                      "area_code": "122007"
+                    }
+                  }
+                }
+              }
+            ],
+            "payment": {
+              "type": "ON-ORDER"
+            }
+          }
+        }
+      }

--- a/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_update_return.json
+++ b/Lekhha/Retail-Logistics/Flow_A5_Return_Flow/Retail_update_return.json
@@ -1,0 +1,104 @@
+{
+        "context": {
+          "domain": "ONDC:RET10",
+          "country": "IND",
+          "city": "std:080",
+          "core_version": "1.2.0",
+          "action": "update",
+          "transaction_id": "a901c433-d508-4348-b696-05f54714af86",
+          "message_id": "b700e0f6-b2e7-4eae-8bbe-55c91b27cc2d",
+          "timestamp": "2025-04-24T18:02:40.815Z",
+          "bap_uri": "https://pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bap_id": "pramaan.ondc.org/beta/preprod/mock/buyer",
+          "bpp_id": "stageapi.lekhha.com",
+          "bpp_uri": "https://stageapi.lekhha.com/sellerApp1",
+          "ttl": "PT30S"
+        },
+        "message": {
+          "update_target": "item",
+          "order": {
+            "id": "SS1745517638223",
+            "fulfillments": [
+              {
+                "type": "Return",
+                "tags": [
+                  {
+                    "code": "return_request",
+                    "list": [
+                      {
+                        "code": "id",
+                        "value": "ce69a8d9-e7b9-4f64-8879-8dffe2783019"
+                      },
+                      {
+                        "code": "item_id",
+                        "value": "676a6179cac4860876a8e30b"
+                      },
+                      {
+                        "code": "item_quantity",
+                        "value": "2"
+                      },
+                      {
+                        "code": "reason_id",
+                        "value": "003"
+                      },
+                      {
+                        "code": "reason_desc",
+                        "value": "some detailed reason for return"
+                      },
+                      {
+                        "code": "images",
+                        "value": "https://some-images-for-item.com"
+                      },
+                      {
+                        "code": "ttl_approval",
+                        "value": "PT24H"
+                      },
+                      {
+                        "code": "ttl_reverseqc",
+                        "value": "P3D"
+                      }
+                    ]
+                  },
+                  {
+                    "code": "return_request",
+                    "list": [
+                      {
+                        "code": "id",
+                        "value": "9f4b8ecb-8389-4034-98f1-f371436e1e4e"
+                      },
+                      {
+                        "code": "item_id",
+                        "value": "676a6126cac4860876a8e309"
+                      },
+                      {
+                        "code": "item_quantity",
+                        "value": "3"
+                      },
+                      {
+                        "code": "reason_id",
+                        "value": "003"
+                      },
+                      {
+                        "code": "reason_desc",
+                        "value": "some detailed reason for return"
+                      },
+                      {
+                        "code": "images",
+                        "value": "https://some-images-for-item.com"
+                      },
+                      {
+                        "code": "ttl_approval",
+                        "value": "PT24H"
+                      },
+                      {
+                        "code": "ttl_reverseqc",
+                        "value": "P3D"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }


### PR DESCRIPTION
Logistics logs for Retail Seller as LBNP - Flows A1, A2, A3, A5

Please note that RET10 v1.2 flows, IGM flows v1.2 and RSF v2.0 flows are already approved.
So as informed, submitting this PR is for the logistics flows for Retail Seller as LBNP.

Further, pls note that flow A3 is NACKed as IGM is implemented for v1.2 while the Pramaan flow A3 is enabled for v1.0

Regards.